### PR TITLE
refactor(sandbox): remove network mode validation for CODE_INTERPRETE…

### DIFF
--- a/agentrun/sandbox/model.py
+++ b/agentrun/sandbox/model.py
@@ -337,19 +337,6 @@ class TemplateInput(BaseModel):
                     f"the current disk size is {self.disk_size}"
                 )
 
-        if (
-            self.template_type == TemplateType.CODE_INTERPRETER
-            or self.template_type == TemplateType.AIO
-        ):
-            if (
-                self.network_configuration
-                and self.network_configuration.network_mode
-                == TemplateNetworkMode.PRIVATE
-            ):
-                raise ValueError(
-                    "when template_type is CODE_INTERPRETER，"
-                    "network_mode cannot be PRIVATE"
-                )
         return self
 
 


### PR DESCRIPTION
…R template type

Removed the validation logic that prevented CODE_INTERPRETER and AIO template types from using PRIVATE network mode, as this restriction is no longer needed.

移除了阻止CODE_INTERPRETER和AIO模板类型使用PRIVATE网络模式的验证逻辑，因为此限制不再需要。

Change-Id: Ice27c23b6833956f59a863105d9583b29de70076

> Thank you for creating a pull request to contribute to Serverless Devs agentrun-sdk-python code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
> Please select one of the PR types below to complete 

---------------------

## Fix bugs

**Bug detail**
> The specific manifestation of the bug or the associated issue.

**Pull request tasks**
- [ ] Add test cases for the changes
- [ ] Passed the CI test

---------------------

## Update docs

**Reason for update**
> Why do you need to update your documentation?

**Pull request tasks**
- [ ] Update Chinese documentation
- [ ] Update English documentation

---------------------

## Add contributor

**Contributed content**
- [ ] Code
- [ ] Document

**Content detail**
```
if content_type == 'code' || content_type == 'document':
    please tell us `PR url`，like: https://github.com/Serverless-Devs/agentrun-sdk-python/pull/1
else:
    please describe your contribution in detail
```

---------------------

## Others

**Reason for update**
> Why do you need to update your documentation?
