### PR TITLE
ci: raise coverage thresholds from 0% to meaningful levels

### DIFF
--- a/coverage.yaml
+++ b/coverage.yaml
@@ -3,42 +3,82 @@
 #
 # 注意：文件排除配置已迁移到 pyproject.toml 的 [tool.coverage.*] 部分
 # Note: File exclusion settings have been moved to [tool.coverage.*] in pyproject.toml
+#
+# 调整策略 / Calibration strategy:
+# - 全量阈值取自当前真实覆盖率（line 90.74% / branch 82.85%）下方约 5% 的 buffer，
+#   作为"不回退"闸；既能挡住明显回归，又不会被 CI 抖动误伤。
+# - 增量阈值更高一些，推动新增代码自带测试；首次新建文件等极端情况下仍可通过。
+# - memory_collection 和 conversation_service 历史覆盖率较低，单独 override
+#   到不严于当前现状的水位，等待后续专项补测试再统一上调。
+#
+# Calibration strategy:
+# - Full thresholds sit ~5% below current real coverage (line 90.74% / branch 82.85%)
+#   to act as a "no regression" gate without flapping on CI noise.
+# - Incremental thresholds are higher to drive tests for new code.
+# - memory_collection / conversation_service have historically lower coverage;
+#   their overrides sit no stricter than today and will be tightened in a
+#   dedicated test-improvement pass later.
 
 # ============================================================================
 # 全量代码覆盖率要求
 # ============================================================================
 full:
   # 分支覆盖率要求 (百分比)
-  branch_coverage: 0
+  branch_coverage: 78
   # 行覆盖率要求 (百分比)
-  line_coverage: 0
+  line_coverage: 85
 
 # ============================================================================
 # 增量代码覆盖率要求 (相对于基准分支的变更代码)
 # ============================================================================
 incremental:
   # 分支覆盖率要求 (百分比)
-  branch_coverage: 0
+  branch_coverage: 75
   # 行覆盖率要求 (百分比)
-  line_coverage: 0
+  line_coverage: 85
 
 # ============================================================================
 # 特定目录的覆盖率要求
 # 可以为特定目录设置不同的覆盖率阈值
 # ============================================================================
 directory_overrides:
-  # 示例：为特定目录设置不同的阈值
-   agentrun/knowledgebase:
-     full:
-       branch_coverage: 0
-       line_coverage: 0
-     incremental:
-       branch_coverage: 0
-       line_coverage: 0
-   agentrun/utils:
-     full:
-       branch_coverage: 90
-       line_coverage: 90
-     incremental:
-       branch_coverage: 90
-       line_coverage: 90
+  # utils 模块要求高覆盖率（基础设施代码）
+  # / utils module is infrastructure code, requires high coverage
+  agentrun/utils:
+    full:
+      branch_coverage: 90
+      line_coverage: 90
+    incremental:
+      branch_coverage: 90
+      line_coverage: 90
+
+  # knowledgebase 历史保持高覆盖率
+  # / knowledgebase has historically maintained high coverage
+  agentrun/knowledgebase:
+    full:
+      branch_coverage: 90
+      line_coverage: 95
+    incremental:
+      branch_coverage: 90
+      line_coverage: 90
+
+  # memory_collection 历史 branch 覆盖率较低（56.11%），先放行不回退
+  # / memory_collection has historically low branch coverage (56.11%); allow
+  # current state, plan to tighten later
+  agentrun/memory_collection:
+    full:
+      branch_coverage: 50
+      line_coverage: 80
+    incremental:
+      branch_coverage: 75
+      line_coverage: 85
+
+  # conversation_service 历史覆盖率较低（line 70.68% / branch 64.94%）
+  # / conversation_service has historically lower coverage; allow current state
+  agentrun/conversation_service:
+    full:
+      branch_coverage: 60
+      line_coverage: 65
+    incremental:
+      branch_coverage: 75
+      line_coverage: 85


### PR DESCRIPTION
加两道 CI 卡点，把 SDK 的回归保护从"形同虚设"提到"防得住典型回归"。

开发者改了 `__xxx_async_template.py` 但忘跑 `make codegen`，对应的 `xxx.py` 就和 template 脱节，下次别人跑 codegen 会被覆盖。CI 现在
跑 `make codegen && git diff --exit-code`，发现 diff 直接 fail 并提示 本地补跑 `make codegen` 后提交。

零风险：当前 main 上 `make codegen` 输出零 diff，新 step 立即就能过。

`coverage.yaml` 之前 full / incremental 全设 0，等于不卡。
基于本地实测当前覆盖率（line 90.74% / branch 82.85%）设：

- 全量阈值：line 85 / branch 78（留 ~5% buffer 防 CI 抖动误伤）
- 增量阈值：line 85 / branch 75（推动新代码自带测试）
- directory_overrides：
  - utils: 90/90（基础设施代码，保持高线）
  - knowledgebase: 95/90（历史高覆盖）
  - memory_collection: 80/50（历史短板，不严于现状，先不回退）
  - conversation_service: 65/60（历史短板，同上）

`uv run --python 3.10 --all-extras python scripts/check_coverage.py` 本地跑通 23 项检查全 ✅。

- pyink/isort 格式 check：当前 19 个存量文件不合规（含 `tests/e2e/test_workspace_id.py` 等），需要先 reformat 再加 check。
- ruff/pylint lint check
- 多 Python 版本矩阵（目前只跑 3.10）
- E2E on CI（需要 Secret 配 AccessKey）

Change-Id: I8bd1fb2f3262fe77143d606e5f0ebb9125cf0932
Co-developed-by: Claude <noreply@anthropic.com>

> Thank you for creating a pull request to contribute to Serverless Devs agentrun-sdk-python code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
> Please select one of the PR types below to complete 

---------------------

## Fix bugs

**Bug detail**
> The specific manifestation of the bug or the associated issue.

**Pull request tasks**
- [ ] Add test cases for the changes
- [ ] Passed the CI test

---------------------

## Update docs

**Reason for update**
> Why do you need to update your documentation?

**Pull request tasks**
- [ ] Update Chinese documentation
- [ ] Update English documentation

---------------------

## Add contributor

**Contributed content**
- [ ] Code
- [ ] Document

**Content detail**
```
if content_type == 'code' || content_type == 'document':
    please tell us `PR url`，like: https://github.com/Serverless-Devs/agentrun-sdk-python/pull/1
else:
    please describe your contribution in detail
```

---------------------

## Others

**Reason for update**
> Why do you need to update your documentation?
