### PR TITLE
Return reasoning content from model output

### DIFF
--- a/agentrun/server/agui_protocol.py
+++ b/agentrun/server/agui_protocol.py
@@ -31,10 +31,7 @@ from fastapi.responses import StreamingResponse
 import pydash
 
 from ..utils.helper import merge, MergeOptions
-from ..utils.reasoning import (
-    get_reasoning_content,
-    is_thinking_enabled_from_env,
-)
+from ..utils.reasoning import get_reasoning_content
 from .model import (
     AgentEvent,
     AgentRequest,
@@ -466,8 +463,6 @@ class AGUIProtocolHandler(BaseProtocolHandler):
             ToolCallStartEvent,
         )
 
-        thinking_enabled = is_thinking_enabled_from_env()
-
         # RAW 事件直接透传
         if event.event == EventType.RAW:
             raw_data = event.data.get("raw", "")
@@ -478,34 +473,31 @@ class AGUIProtocolHandler(BaseProtocolHandler):
             return
 
         if event.event == EventType.REASONING:
-            if thinking_enabled:
-                reasoning_content = (
-                    event.data.get("delta")
-                    or get_reasoning_content(event.data)
-                    or ""
+            reasoning_content = (
+                event.data.get("delta")
+                or get_reasoning_content(event.data)
+                or ""
+            )
+            if reasoning_content:
+                for sse_data in state.end_text_if_open(self._encoder):
+                    yield sse_data
+                for sse_data in state.end_all_tools(self._encoder):
+                    yield sse_data
+                for sse_data in state.ensure_reasoning_started():
+                    yield sse_data
+                yield _encode_reasoning_event(
+                    "REASONING_MESSAGE_CONTENT",
+                    messageId=state.reasoning.message_id,
+                    delta=reasoning_content,
                 )
-                if reasoning_content:
-                    for sse_data in state.end_text_if_open(self._encoder):
-                        yield sse_data
-                    for sse_data in state.end_all_tools(self._encoder):
-                        yield sse_data
-                    for sse_data in state.ensure_reasoning_started():
-                        yield sse_data
-                    yield _encode_reasoning_event(
-                        "REASONING_MESSAGE_CONTENT",
-                        messageId=state.reasoning.message_id,
-                        delta=reasoning_content,
-                    )
             return
 
         # TEXT 事件：在首个 TEXT 前注入 TEXT_MESSAGE_START
         # AG-UI 协议要求：发送 TEXT_MESSAGE_START 前必须先结束所有未结束的 TOOL_CALL
         if event.event == EventType.TEXT:
-            addition = self._strip_reasoning_from_addition(
-                event.addition, thinking_enabled
-            )
+            addition = self._strip_reasoning_from_addition(event.addition)
             addition_reasoning = get_reasoning_content(event.addition or {})
-            if thinking_enabled and addition_reasoning:
+            if addition_reasoning:
                 for sse_data in state.ensure_reasoning_started():
                     yield sse_data
                 yield _encode_reasoning_event(
@@ -874,7 +866,6 @@ class AGUIProtocolHandler(BaseProtocolHandler):
     def _strip_reasoning_from_addition(
         self,
         addition: Optional[Dict[str, Any]],
-        thinking_enabled: bool,
     ) -> Optional[Dict[str, Any]]:
         if not addition:
             return addition
@@ -890,8 +881,6 @@ class AGUIProtocolHandler(BaseProtocolHandler):
             else:
                 stripped.pop("additional_kwargs", None)
 
-        if not thinking_enabled:
-            return stripped
         return stripped or None
 
     async def _error_stream(self, message: str) -> AsyncIterator[str]:

--- a/agentrun/server/openai_protocol.py
+++ b/agentrun/server/openai_protocol.py
@@ -15,10 +15,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 import pydash
 
-from ..utils.reasoning import (
-    get_reasoning_content,
-    is_thinking_enabled_from_env,
-)
+from ..utils.reasoning import get_reasoning_content
 from ..utils.helper import merge, MergeOptions
 from .model import (
     AgentEvent,
@@ -304,7 +301,6 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
         # 状态追踪
         sent_role = False
         has_text = False
-        thinking_enabled = is_thinking_enabled_from_env()
         tool_call_index = -1  # 从 -1 开始，第一个工具调用时变为 0
         # 工具调用状态：{tool_id: {"started": bool, "index": int}}
         tool_call_states: Dict[str, Dict[str, Any]] = {}
@@ -341,19 +337,18 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
                             event.addition_merge_options,
                         )
 
-                    self._apply_reasoning_gate(delta, thinking_enabled)
+                    self._promote_reasoning_content(delta)
                     yield self._build_chunk(context, delta)
                 continue
 
             if event.event == EventType.REASONING:
-                if thinking_enabled:
-                    reasoning_content = event.data.get("delta", "")
-                    if reasoning_content:
-                        has_text = True
-                        yield self._build_chunk(
-                            context,
-                            {"reasoning_content": reasoning_content},
-                        )
+                reasoning_content = event.data.get("delta", "")
+                if reasoning_content:
+                    has_text = True
+                    yield self._build_chunk(
+                        context,
+                        {"reasoning_content": reasoning_content},
+                    )
                 continue
 
             # TOOL_CALL_CHUNK 事件
@@ -401,7 +396,7 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
                             event.addition_merge_options,
                         )
 
-                    self._apply_reasoning_gate(delta, thinking_enabled)
+                    self._promote_reasoning_content(delta)
                     yield self._build_chunk(context, delta)
                 continue
 
@@ -477,7 +472,6 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
         """
         content_parts: List[str] = []
         reasoning_parts: List[str] = []
-        thinking_enabled = is_thinking_enabled_from_env()
         # 工具调用状态：{tool_id: {id, name, arguments}}
         tool_call_map: Dict[str, Dict[str, Any]] = {}
         has_tool_calls = False
@@ -486,12 +480,12 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
             if event.event == EventType.TEXT:
                 content_parts.append(event.data.get("delta", ""))
                 reasoning_content = get_reasoning_content(event.addition or {})
-                if thinking_enabled and reasoning_content:
+                if reasoning_content:
                     reasoning_parts.append(reasoning_content)
 
             elif event.event == EventType.REASONING:
                 reasoning_content = event.data.get("delta", "")
-                if thinking_enabled and reasoning_content:
+                if reasoning_content:
                     reasoning_parts.append(reasoning_content)
 
             elif event.event == EventType.TOOL_CALL_CHUNK:
@@ -564,18 +558,14 @@ class OpenAIProtocolHandler(BaseProtocolHandler):
 
         return merge(delta, addition, **(merge_options or {}))
 
-    def _apply_reasoning_gate(
-        self,
-        payload: Dict[str, Any],
-        thinking_enabled: bool,
-    ) -> None:
-        if thinking_enabled:
-            reasoning_content = get_reasoning_content(payload)
-            if reasoning_content is not None:
-                payload["reasoning_content"] = reasoning_content
-            return
-
+    def _promote_reasoning_content(self, payload: Dict[str, Any]) -> None:
+        reasoning_content = get_reasoning_content(payload)
         payload.pop("reasoning_content", None)
         additional_kwargs = payload.get("additional_kwargs")
         if isinstance(additional_kwargs, dict):
             additional_kwargs.pop("reasoning_content", None)
+            if not additional_kwargs:
+                payload.pop("additional_kwargs", None)
+
+        if reasoning_content:
+            payload["reasoning_content"] = reasoning_content

--- a/tests/e2e/test_reasoning_protocol.py
+++ b/tests/e2e/test_reasoning_protocol.py
@@ -71,14 +71,13 @@ async def test_openai_stream_reasoning_content_gate(
     assert response.status_code == 200
     events = _parse_sse_events(response.text)
     deltas = [
-        (event.get("choices") or [{}])[0].get("delta") or {}
-        for event in events
+        (event.get("choices") or [{}])[0].get("delta") or {} for event in events
     ]
     reasoning = "".join(delta.get("reasoning_content", "") for delta in deltas)
     content = "".join(delta.get("content", "") for delta in deltas)
 
     assert content == "answer"
-    assert reasoning == ("thinking" if thinking_enabled else "")
+    assert reasoning == "thinking"
     assert all("additional_kwargs" not in delta for delta in deltas)
 
 
@@ -104,10 +103,7 @@ async def test_openai_non_stream_reasoning_content_gate(
     assert response.status_code == 200
     message = response.json()["choices"][0]["message"]
     assert message["content"] == "answer"
-    if thinking_enabled:
-        assert message["reasoning_content"] == "thinking"
-    else:
-        assert "reasoning_content" not in message
+    assert message["reasoning_content"] == "thinking"
 
 
 @pytest.mark.parametrize("thinking_enabled", [True, False])
@@ -140,14 +136,7 @@ async def test_agui_reasoning_events_gate(
     )
 
     assert content == "answer"
-    if thinking_enabled:
-        assert reasoning == "thinking"
-        assert event_types.index("REASONING_MESSAGE_CONTENT") < event_types.index(
-            "TEXT_MESSAGE_START"
-        )
-    else:
-        assert reasoning == ""
-        assert all(
-            not event_type.startswith("REASONING")
-            for event_type in event_types
-        )
+    assert reasoning == "thinking"
+    assert event_types.index("REASONING_MESSAGE_CONTENT") < event_types.index(
+        "TEXT_MESSAGE_START"
+    )

--- a/tests/unittests/server/test_agui_protocol.py
+++ b/tests/unittests/server/test_agui_protocol.py
@@ -1196,7 +1196,7 @@ class TestAGUIProtocolToolCallBranches:
 
 
 class TestAGUIReasoningContent:
-    """测试 AG-UI reasoning 事件输出开关"""
+    """测试 AG-UI reasoning 事件输出"""
 
     def get_client(self, invoke_agent):
         server = AgentRunServer(invoke_agent=invoke_agent)
@@ -1228,7 +1228,7 @@ class TestAGUIReasoningContent:
         assert reasoning_event["delta"] == "thinking"
         assert "TEXT_MESSAGE_CONTENT" in types
 
-    def test_stream_suppresses_reasoning_when_thinking_disabled(
+    def test_stream_includes_reasoning_when_thinking_disabled(
         self, monkeypatch
     ):
         monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": false}')
@@ -1246,9 +1246,14 @@ class TestAGUIReasoningContent:
         )
 
         events = _agui_sse_events(response)
-        assert "REASONING_MESSAGE_CONTENT" not in [
-            event["type"] for event in events
-        ]
+        types = [event["type"] for event in events]
+        reasoning_event = next(
+            event
+            for event in events
+            if event["type"] == "REASONING_MESSAGE_CONTENT"
+        )
+        assert "REASONING_START" in types
+        assert reasoning_event["delta"] == "thinking"
         text_event = next(
             event for event in events if event["type"] == "TEXT_MESSAGE_CONTENT"
         )
@@ -1257,7 +1262,7 @@ class TestAGUIReasoningContent:
     def test_stream_promotes_chunk_additional_kwargs_reasoning(
         self, monkeypatch
     ):
-        monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": true}')
+        monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": false}')
 
         async def invoke_agent(request: AgentRequest):
             yield SimpleNamespace(
@@ -1282,9 +1287,7 @@ class TestAGUIReasoningContent:
         assert reasoning_event["delta"] == "thinking"
         assert text_event["delta"] == "answer"
 
-    def test_text_addition_reasoning_is_emitted_before_text(
-        self, monkeypatch
-    ):
+    def test_text_addition_reasoning_is_emitted_before_text(self, monkeypatch):
         monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": true}')
 
         async def invoke_agent(request: AgentRequest):
@@ -1314,7 +1317,7 @@ class TestAGUIReasoningContent:
         assert text_event["delta"] == "answer"
         assert "additional_kwargs" not in text_event
 
-    def test_text_addition_reasoning_is_stripped_when_thinking_disabled(
+    def test_text_addition_reasoning_is_emitted_when_thinking_disabled(
         self, monkeypatch
     ):
         monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": false}')
@@ -1335,7 +1338,11 @@ class TestAGUIReasoningContent:
 
         events = _agui_sse_events(response)
         types = [event["type"] for event in events]
-        assert all(not event_type.startswith("REASONING") for event_type in types)
+        assert types.index("REASONING_MESSAGE_CONTENT") < types.index(
+            "TEXT_MESSAGE_START"
+        )
+        assert "REASONING_MESSAGE_END" in types
+        assert "REASONING_END" in types
         text_event = next(
             event for event in events if event["type"] == "TEXT_MESSAGE_CONTENT"
         )

--- a/tests/unittests/server/test_openai_protocol.py
+++ b/tests/unittests/server/test_openai_protocol.py
@@ -1017,7 +1017,7 @@ class TestOpenAIProtocolRawEvent:
 
 
 class TestOpenAIReasoningContent:
-    """测试 OpenAI reasoning_content 输出开关"""
+    """测试 OpenAI reasoning_content 输出"""
 
     def get_client(self, invoke_agent):
         server = AgentRunServer(invoke_agent=invoke_agent)
@@ -1042,10 +1042,12 @@ class TestOpenAIReasoningContent:
         )
 
         events = _openai_sse_events(response)
-        assert events[0]["choices"][0]["delta"]["reasoning_content"] == "thinking"
+        assert (
+            events[0]["choices"][0]["delta"]["reasoning_content"] == "thinking"
+        )
         assert events[1]["choices"][0]["delta"]["content"] == "answer"
 
-    def test_stream_suppresses_reasoning_when_thinking_disabled(
+    def test_stream_includes_reasoning_when_thinking_disabled(
         self, monkeypatch
     ):
         monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": false}')
@@ -1066,11 +1068,10 @@ class TestOpenAIReasoningContent:
         )
 
         events = _openai_sse_events(response)
-        assert all(
-            "reasoning_content" not in event["choices"][0]["delta"]
-            for event in events
+        assert (
+            events[0]["choices"][0]["delta"]["reasoning_content"] == "thinking"
         )
-        assert events[0]["choices"][0]["delta"]["content"] == "answer"
+        assert events[1]["choices"][0]["delta"]["content"] == "answer"
 
     def test_non_stream_includes_reasoning_when_thinking_enabled(
         self, monkeypatch
@@ -1098,7 +1099,7 @@ class TestOpenAIReasoningContent:
         assert message["content"] == "answer"
         assert message["reasoning_content"] == "thinking"
 
-    def test_non_stream_suppresses_reasoning_when_thinking_disabled(
+    def test_non_stream_includes_reasoning_when_thinking_disabled(
         self, monkeypatch
     ):
         monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": false}')
@@ -1122,12 +1123,12 @@ class TestOpenAIReasoningContent:
 
         message = response.json()["choices"][0]["message"]
         assert message["content"] == "answer"
-        assert "reasoning_content" not in message
+        assert message["reasoning_content"] == "thinking"
 
     def test_stream_promotes_chunk_additional_kwargs_reasoning(
         self, monkeypatch
     ):
-        monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": true}')
+        monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": false}')
 
         async def invoke_agent(request: AgentRequest):
             yield SimpleNamespace(
@@ -1144,8 +1145,37 @@ class TestOpenAIReasoningContent:
         )
 
         events = _openai_sse_events(response)
-        assert events[0]["choices"][0]["delta"]["reasoning_content"] == "thinking"
+        assert (
+            events[0]["choices"][0]["delta"]["reasoning_content"] == "thinking"
+        )
         assert events[1]["choices"][0]["delta"]["content"] == "answer"
+
+    def test_stream_promotes_text_addition_reasoning_when_thinking_disabled(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("MODEL_PARAMETER_RULES", '{"thinking": false}')
+
+        async def invoke_agent(request: AgentRequest):
+            yield AgentEvent(
+                event=EventType.TEXT,
+                data={"delta": "answer"},
+                addition={
+                    "additional_kwargs": {"reasoning_content": "thinking"}
+                },
+            )
+
+        response = self.get_client(invoke_agent).post(
+            "/openai/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            },
+        )
+
+        delta = _openai_sse_events(response)[0]["choices"][0]["delta"]
+        assert delta["content"] == "answer"
+        assert delta["reasoning_content"] == "thinking"
+        assert "additional_kwargs" not in delta
 
     def test_parses_request_message_reasoning_content(self):
         captured_request = {}


### PR DESCRIPTION
## Summary
- Remove protocol-level `MODEL_PARAMETER_RULES` gating from OpenAI Chat Completions and AG-UI reasoning output conversion.
- Emit reasoning only when the returned `reasoning_content` payload is non-empty.
- Keep reasoning extraction from `additional_kwargs.reasoning_content`, while stripping the nested transport-only field from protocol payloads.

## Validation
- `uv run --python 3.11 --dev --extra server pytest -q tests/unittests/server/test_openai_protocol.py tests/unittests/server/test_agui_protocol.py tests/unittests/server/test_reasoning.py`
- `uv run --python 3.11 --dev --extra server pytest -q tests/unittests/server`
- `uv run --python 3.11 --dev --extra server ruff check agentrun/server/openai_protocol.py agentrun/server/agui_protocol.py tests/unittests/server/test_openai_protocol.py tests/unittests/server/test_agui_protocol.py`
- `git diff --check`

## Notes
`MODEL_PARAMETER_RULES` can still be used by the runtime/model-call layer to control whether the model thinks. The SDK response protocol layer now trusts the actual model output: if reasoning is returned, it is surfaced; if reasoning is absent or empty, no reasoning field/event is emitted.