### PR TITLE
修正 OpenAPI 固定请求头日志与异步测试

### DIFF
--- a/agentrun/tool/api/openapi.py
+++ b/agentrun/tool/api/openapi.py
@@ -446,7 +446,8 @@ class ToolOpenAPIClient:
         url, auth = self._build_ram_auth(url)
 
         logger.debug(
-            f"Calling FunctionCall tool: {method} {url} with args={arguments}"
+            "Calling FunctionCall tool:"
+            f" {method} {url} with args={request_arguments}"
         )
 
         with httpx.Client(
@@ -510,7 +511,7 @@ class ToolOpenAPIClient:
 
         logger.debug(
             f"Calling FunctionCall tool async: {method} {url} with"
-            f" args={arguments}"
+            f" args={request_arguments}"
         )
 
         async with httpx.AsyncClient(

--- a/tests/unittests/tool/test_openapi.py
+++ b/tests/unittests/tool/test_openapi.py
@@ -966,7 +966,7 @@ class TestToolOpenAPIClient:
         mock_client_instance.__aenter__ = AsyncMock(
             return_value=mock_client_instance
         )
-        mock_client_instance.__aexit__ = AsyncMock()
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
         mock_async_client_class.return_value = mock_client_instance
 
         spec = json.dumps({


### PR DESCRIPTION
## 改动说明

补充修复 #119 合入后遗留的 review feedback：

- `call_tool` / `call_tool_async` 的 debug 日志改为打印实际发送的 `request_arguments`。
- 避免过滤前 `arguments` 中的 fixed-header-like 参数进入日志。
- 新增 fixed header async 测试中将 `__aexit__` 设为 `AsyncMock(return_value=False)`，避免 context manager mock 吞异常。

## 验证

- `uv run pytest tests/unittests/tool/test_openapi.py -q`
- `uv run pyink --check --config pyproject.toml agentrun/tool/api/openapi.py tests/unittests/tool/test_openapi.py`
- `uv run isort --check-only agentrun/tool/api/openapi.py tests/unittests/tool/test_openapi.py`
- `git diff --check -- agentrun/tool/api/openapi.py tests/unittests/tool/test_openapi.py`

## 关联

- Follow-up for #119