### PR TITLE
让 SDK 日志时间在 UTC 容器中稳定显示东八区

### DIFF
--- a/agentrun/utils/log.py
+++ b/agentrun/utils/log.py
@@ -6,10 +6,19 @@ This module configures the logging system for AgentRun SDK.
 
 import logging
 import os
+import time
 
 from dotenv import load_dotenv
 
 load_dotenv()
+
+UTC8_OFFSET_SECONDS = 8 * 60 * 60
+
+
+def _utc8_converter(timestamp: float) -> time.struct_time:
+    """Return a UTC+8 ``struct_time`` for logging.Formatter."""
+
+    return time.gmtime(timestamp + UTC8_OFFSET_SECONDS)
 
 
 class CustomFormatter(logging.Formatter):
@@ -48,11 +57,17 @@ class CustomFormatter(logging.Formatter):
                     f" {self.DIM}%(pathname)s:%(lineno)s{self.RESET}"
                     "\n%(message)s"
                 )
-            self._formatters[level] = logging.Formatter(fmt)
+            self._formatters[level] = self._create_formatter(fmt)
         self._default = logging.Formatter(
             "\n%(levelname)s [%(name)s] %(asctime)s"
             " %(pathname)s:%(lineno)s\n%(message)s"
         )
+        self._default.converter = _utc8_converter
+
+    def _create_formatter(self, fmt: str) -> logging.Formatter:
+        formatter = logging.Formatter(fmt)
+        formatter.converter = _utc8_converter
+        return formatter
 
     def format(self, record: logging.LogRecord) -> str:
         return self._formatters.get(record.levelname, self._default).format(

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -1,0 +1,66 @@
+"""Unit tests for AgentRun SDK logging."""
+
+import logging
+import time
+
+import pytest
+
+from agentrun.utils.log import CustomFormatter, _utc8_converter
+
+
+def make_record(level: int, level_name: str) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="agentrun-logger",
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    record.created = 0
+    record.levelname = level_name
+    return record
+
+
+def test_utc8_converter_is_independent_from_local_timezone():
+    assert _utc8_converter(0) == time.gmtime(8 * 60 * 60)
+
+
+def test_custom_formatter_uses_utc8_for_all_inner_formatters():
+    formatter = CustomFormatter()
+    expected = time.gmtime(8 * 60 * 60)
+
+    for inner in formatter._formatters.values():
+        assert inner.converter(0) == expected
+    assert formatter._default.converter(0) == expected
+
+
+@pytest.mark.parametrize(
+    ("level", "level_name"),
+    [
+        (logging.DEBUG, "DEBUG"),
+        (logging.INFO, "INFO"),
+        (logging.WARNING, "WARNING"),
+        (logging.ERROR, "ERROR"),
+        (logging.CRITICAL, "CRITICAL"),
+    ],
+)
+def test_custom_formatter_formats_known_levels_in_utc8(
+    level: int, level_name: str
+):
+    formatter = CustomFormatter()
+
+    output = formatter.format(make_record(level, level_name))
+
+    assert "1970-01-01 08:00:00" in output
+    assert "1970-01-01 00:00:00" not in output
+
+
+def test_custom_formatter_formats_fallback_level_in_utc8():
+    formatter = CustomFormatter()
+
+    output = formatter.format(make_record(5, "TRACE"))
+
+    assert "1970-01-01 08:00:00" in output
+    assert "1970-01-01 00:00:00" not in output


### PR DESCRIPTION
Constraint: Aone 83336550 requires quick-created Agent logs to show UTC+8 instead of UTC.

Rejected: process TZ or frontend conversion | broader blast radius and does not target SDK-emitted asctime.

Confidence: high

Scope-risk: narrow

Directive: Keep timezone policy local to SDK formatter unless future requirements make it configurable.

Tested: uv run pytest tests/unittests/test_log.py -q; TZ=UTC/Asia/Shanghai/America/Los_Angeles uv run pytest tests/unittests/test_log.py -q; uv run mypy --config-file mypy.ini agentrun/utils/log.py tests/unittests/test_log.py; git diff --check; independent code-reviewer APPROVE; architect CLEAR; UltraQA PASS.

Change-Id: I4a49664dcba0fe023fa0847b1046a0e3a9ae72ec
Co-developed-by: Codex <noreply@openai.com>
Not-tested: full repo mypy has unrelated pre-existing examples/conversation_service_langgraph_server.py:175 error; full pytest includes credential-gated e2e and was not used as merge gate.

> Thank you for creating a pull request to contribute to Serverless Devs agentrun-sdk-python code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
> Please select one of the PR types below to complete 

---------------------

## Fix bugs

**Bug detail**
> The specific manifestation of the bug or the associated issue.

**Pull request tasks**
- [ ] Add test cases for the changes
- [ ] Passed the CI test

---------------------

## Update docs

**Reason for update**
> Why do you need to update your documentation?

**Pull request tasks**
- [ ] Update Chinese documentation
- [ ] Update English documentation

---------------------

## Add contributor

**Contributed content**
- [ ] Code
- [ ] Document

**Content detail**
```
if content_type == 'code' || content_type == 'document':
    please tell us `PR url`，like: https://github.com/Serverless-Devs/agentrun-sdk-python/pull/1
else:
    please describe your contribution in detail
```

---------------------

## Others

**Reason for update**
> Why do you need to update your documentation?
