### PR TITLE
Normalize model rate limits into AG-UI run errors

### DIFF
--- a/agentrun/integration/langgraph/agent_converter.py
+++ b/agentrun/integration/langgraph/agent_converter.py
@@ -29,6 +29,10 @@
 import json
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from agentrun.server.error_utils import (
+    build_error_event_data,
+    format_error_message,
+)
 from agentrun.server.model import AgentResult, EventType
 from agentrun.utils.log import logger
 
@@ -941,71 +945,53 @@ class AgentRunConverter:
         # 7. LLM 错误
         elif event_type == "on_llm_error":
             error = data.get("error")
-            error_message = ""
-            if error is not None:
-                if isinstance(error, Exception):
-                    error_message = f"{type(error).__name__}: {str(error)}"
-                elif isinstance(error, str):
-                    error_message = error
-                else:
-                    error_message = str(error)
+            error_message = format_error_message(error)
 
             yield AgentResult(
                 event=EventType.ERROR,
-                data={
-                    "message": f"LLM error: {error_message}",
-                    "code": "LLM_ERROR",
-                },
+                data=build_error_event_data(
+                    error,
+                    fallback_code="LLM_ERROR",
+                    fallback_message=f"LLM error: {error_message}",
+                ),
             )
 
         # 8. Chain 错误
         elif event_type == "on_chain_error":
             error = data.get("error")
             chain_name = event_dict.get("name", "")
-            error_message = ""
-            if error is not None:
-                if isinstance(error, Exception):
-                    error_message = f"{type(error).__name__}: {str(error)}"
-                elif isinstance(error, str):
-                    error_message = error
-                else:
-                    error_message = str(error)
+            error_message = format_error_message(error)
 
             yield AgentResult(
                 event=EventType.ERROR,
-                data={
-                    "message": (
+                data=build_error_event_data(
+                    error,
+                    fallback_code="CHAIN_ERROR",
+                    fallback_message=(
                         f"Chain '{chain_name}' error: {error_message}"
                         if chain_name
                         else error_message
                     ),
-                    "code": "CHAIN_ERROR",
-                },
+                ),
             )
 
         # 9. Retriever 错误
         elif event_type == "on_retriever_error":
             error = data.get("error")
             retriever_name = event_dict.get("name", "")
-            error_message = ""
-            if error is not None:
-                if isinstance(error, Exception):
-                    error_message = f"{type(error).__name__}: {str(error)}"
-                elif isinstance(error, str):
-                    error_message = error
-                else:
-                    error_message = str(error)
+            error_message = format_error_message(error)
 
             yield AgentResult(
                 event=EventType.ERROR,
-                data={
-                    "message": (
+                data=build_error_event_data(
+                    error,
+                    fallback_code="RETRIEVER_ERROR",
+                    fallback_message=(
                         f"Retriever '{retriever_name}' error: {error_message}"
                         if retriever_name
                         else error_message
                     ),
-                    "code": "RETRIEVER_ERROR",
-                },
+                ),
             )
 
     # =========================================================================

--- a/agentrun/integration/langgraph/agent_converter.py
+++ b/agentrun/integration/langgraph/agent_converter.py
@@ -30,10 +30,7 @@ import json
 from typing import Any, Dict, Iterator, List, Optional, Union
 
 from agentrun.server.model import AgentResult, EventType
-from agentrun.utils.error_utils import (
-    build_error_event_data,
-    is_rate_limited_error,
-)
+from agentrun.utils.error_utils import build_error_event_data, is_model_error
 from agentrun.utils.log import logger
 
 # 需要从工具输入中过滤掉的内部字段（LangGraph/MCP 注入的运行时对象）
@@ -961,7 +958,7 @@ class AgentRunConverter:
                     fallback_code="LLM_ERROR",
                     fallback_message=(
                         error_message
-                        if is_rate_limited_error(error)
+                        if is_model_error(error)
                         else f"LLM error: {error_message}"
                     ),
                 ),

--- a/agentrun/integration/langgraph/agent_converter.py
+++ b/agentrun/integration/langgraph/agent_converter.py
@@ -29,11 +29,11 @@
 import json
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from agentrun.server.model import AgentResult, EventType
 from agentrun.utils.error_utils import (
     build_error_event_data,
-    format_error_message,
+    is_rate_limited_error,
 )
-from agentrun.server.model import AgentResult, EventType
 from agentrun.utils.log import logger
 
 # 需要从工具输入中过滤掉的内部字段（LangGraph/MCP 注入的运行时对象）
@@ -945,14 +945,25 @@ class AgentRunConverter:
         # 7. LLM 错误
         elif event_type == "on_llm_error":
             error = data.get("error")
-            error_message = format_error_message(error)
+            error_message = ""
+            if error is not None:
+                if isinstance(error, Exception):
+                    error_message = f"{type(error).__name__}: {str(error)}"
+                elif isinstance(error, str):
+                    error_message = error
+                else:
+                    error_message = str(error)
 
             yield AgentResult(
                 event=EventType.ERROR,
                 data=build_error_event_data(
                     error,
                     fallback_code="LLM_ERROR",
-                    fallback_message=f"LLM error: {error_message}",
+                    fallback_message=(
+                        error_message
+                        if is_rate_limited_error(error)
+                        else f"LLM error: {error_message}"
+                    ),
                 ),
             )
 
@@ -960,7 +971,14 @@ class AgentRunConverter:
         elif event_type == "on_chain_error":
             error = data.get("error")
             chain_name = event_dict.get("name", "")
-            error_message = format_error_message(error)
+            error_message = ""
+            if error is not None:
+                if isinstance(error, Exception):
+                    error_message = f"{type(error).__name__}: {str(error)}"
+                elif isinstance(error, str):
+                    error_message = error
+                else:
+                    error_message = str(error)
 
             yield AgentResult(
                 event=EventType.ERROR,
@@ -978,7 +996,14 @@ class AgentRunConverter:
         elif event_type == "on_retriever_error":
             error = data.get("error")
             retriever_name = event_dict.get("name", "")
-            error_message = format_error_message(error)
+            error_message = ""
+            if error is not None:
+                if isinstance(error, Exception):
+                    error_message = f"{type(error).__name__}: {str(error)}"
+                elif isinstance(error, str):
+                    error_message = error
+                else:
+                    error_message = str(error)
 
             yield AgentResult(
                 event=EventType.ERROR,

--- a/agentrun/integration/langgraph/agent_converter.py
+++ b/agentrun/integration/langgraph/agent_converter.py
@@ -29,7 +29,7 @@
 import json
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from agentrun.server.error_utils import (
+from agentrun.utils.error_utils import (
     build_error_event_data,
     format_error_message,
 )
@@ -964,15 +964,14 @@ class AgentRunConverter:
 
             yield AgentResult(
                 event=EventType.ERROR,
-                data=build_error_event_data(
-                    error,
-                    fallback_code="CHAIN_ERROR",
-                    fallback_message=(
+                data={
+                    "message": (
                         f"Chain '{chain_name}' error: {error_message}"
                         if chain_name
                         else error_message
                     ),
-                ),
+                    "code": "CHAIN_ERROR",
+                },
             )
 
         # 9. Retriever 错误
@@ -983,15 +982,14 @@ class AgentRunConverter:
 
             yield AgentResult(
                 event=EventType.ERROR,
-                data=build_error_event_data(
-                    error,
-                    fallback_code="RETRIEVER_ERROR",
-                    fallback_message=(
+                data={
+                    "message": (
                         f"Retriever '{retriever_name}' error: {error_message}"
                         if retriever_name
                         else error_message
                     ),
-                ),
+                    "code": "RETRIEVER_ERROR",
+                },
             )
 
     # =========================================================================

--- a/agentrun/server/agui_protocol.py
+++ b/agentrun/server/agui_protocol.py
@@ -748,15 +748,11 @@ class AGUIProtocolHandler(BaseProtocolHandler):
                 message=event.data.get("message", ""),
                 code=event.data.get("code"),
             )
-            extra_fields = {}
-            for key in RUN_ERROR_EXTRA_FIELDS:
-                value = event.data.get(key)
-                if value is not None:
-                    extra_fields[key] = value
-                elif event.addition:
-                    value = event.addition.get(key)
-                    if value is not None:
-                        extra_fields[key] = value
+            extra_fields = {
+                key: event.data[key]
+                for key in RUN_ERROR_EXTRA_FIELDS
+                if key in event.data
+            }
             if extra_fields:
                 agui_event = agui_event.model_copy(update=extra_fields)
             yield self._encoder.encode(agui_event)

--- a/agentrun/server/agui_protocol.py
+++ b/agentrun/server/agui_protocol.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
 # ============================================================================
 
 DEFAULT_PREFIX = "/ag-ui/agent"
+RUN_ERROR_EXTRA_FIELDS = ("retryable", "retryAfterMs", "traceId")
 
 
 @dataclass
@@ -743,12 +744,21 @@ class AGUIProtocolHandler(BaseProtocolHandler):
 
         # ERROR 事件
         if event.event == EventType.ERROR:
-            yield self._encoder.encode(
-                RunErrorEvent(
-                    message=event.data.get("message", ""),
-                    code=event.data.get("code"),
-                )
+            agui_event = RunErrorEvent(
+                message=event.data.get("message", ""),
+                code=event.data.get("code"),
             )
+            event_dict = agui_event.model_dump(by_alias=True, exclude_none=True)
+            for key in RUN_ERROR_EXTRA_FIELDS:
+                value = event.data.get(key)
+                if value is not None:
+                    event_dict[key] = value
+                elif event.addition:
+                    value = event.addition.get(key)
+                    if value is not None:
+                        event_dict[key] = value
+            json_str = json.dumps(event_dict, ensure_ascii=False)
+            yield f"event: RUN_ERROR\ndata: {json_str}\n\n"
             return
 
         # STATE 事件

--- a/agentrun/server/agui_protocol.py
+++ b/agentrun/server/agui_protocol.py
@@ -53,7 +53,14 @@ if TYPE_CHECKING:
 # ============================================================================
 
 DEFAULT_PREFIX = "/ag-ui/agent"
-RUN_ERROR_EXTRA_FIELDS = ("retryable", "retryAfterMs", "traceId")
+RUN_ERROR_EXTRA_FIELDS = (
+    "retryable",
+    "retryAfterMs",
+    "traceId",
+    "requestId",
+    "statusCode",
+    "providerCode",
+)
 
 
 @dataclass

--- a/agentrun/server/agui_protocol.py
+++ b/agentrun/server/agui_protocol.py
@@ -748,17 +748,18 @@ class AGUIProtocolHandler(BaseProtocolHandler):
                 message=event.data.get("message", ""),
                 code=event.data.get("code"),
             )
-            event_dict = agui_event.model_dump(by_alias=True, exclude_none=True)
+            extra_fields = {}
             for key in RUN_ERROR_EXTRA_FIELDS:
                 value = event.data.get(key)
                 if value is not None:
-                    event_dict[key] = value
+                    extra_fields[key] = value
                 elif event.addition:
                     value = event.addition.get(key)
                     if value is not None:
-                        event_dict[key] = value
-            json_str = json.dumps(event_dict, ensure_ascii=False)
-            yield f"event: RUN_ERROR\ndata: {json_str}\n\n"
+                        extra_fields[key] = value
+            if extra_fields:
+                agui_event = agui_event.model_copy(update=extra_fields)
+            yield self._encoder.encode(agui_event)
             return
 
         # STATE 事件

--- a/agentrun/server/error_utils.py
+++ b/agentrun/server/error_utils.py
@@ -131,9 +131,10 @@ def _get_value(obj: Any, name: str) -> Optional[Any]:
 
 
 def _get_header(headers: Any, name: str) -> Optional[Any]:
+    target = str(name).lower()
     if isinstance(headers, dict):
         for key, value in headers.items():
-            if str(key).lower() == name:
+            if str(key).lower() == target:
                 return value
         return None
     get = getattr(headers, "get", None)

--- a/agentrun/server/error_utils.py
+++ b/agentrun/server/error_utils.py
@@ -1,0 +1,159 @@
+"""Error helpers for AgentRun server streams."""
+
+import re
+from typing import Any, Dict, Optional
+
+RATE_LIMITED_CODE = "RATE_LIMITED"
+RATE_LIMITED_MESSAGE = "模型当前请求过多，请稍后再试"
+RATE_LIMITED_RETRY_AFTER_MS = 2000
+
+_RATE_LIMIT_CODES = {
+    "ratelimitexceeded",
+    "ratelimited",
+    "resourcethrottled",
+    "throttling",
+    "throttlingquota",
+    "throttlingratequota",
+    "throttlingexception",
+    "toomanyrequests",
+}
+
+_RATE_LIMIT_TEXT_PATTERNS = [
+    re.compile(r"\btoo[-_\s]*many[-_\s]*requests\b", re.IGNORECASE),
+    re.compile(
+        r"\brate[-_\s]*limit(?:ed|[-_\s]*exceeded)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bresource[-_\s]*throttled\b", re.IGNORECASE),
+    re.compile(r"\bthrottling(?:exception| exception| error)\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:http|status|status code|code)\s*[:=]?\s*429\b",
+        re.IGNORECASE,
+    ),
+]
+
+
+def format_error_message(error: Any) -> str:
+    """Format errors consistently with existing LangGraph conversion."""
+    if error is None:
+        return ""
+    if isinstance(error, Exception):
+        return f"{type(error).__name__}: {str(error)}"
+    return str(error)
+
+
+def build_error_event_data(
+    error: Any,
+    *,
+    fallback_code: str,
+    fallback_message: str,
+) -> Dict[str, Any]:
+    """Build AgentEvent ERROR data, normalizing model rate limits."""
+    if not is_rate_limited_error(error):
+        return {"message": fallback_message, "code": fallback_code}
+
+    data: Dict[str, Any] = {
+        "message": RATE_LIMITED_MESSAGE,
+        "code": RATE_LIMITED_CODE,
+        "retryable": True,
+        "retryAfterMs": RATE_LIMITED_RETRY_AFTER_MS,
+    }
+    trace_id = _extract_trace_id(error)
+    if trace_id:
+        data["traceId"] = str(trace_id)
+    return data
+
+
+def is_rate_limited_error(error: Any) -> bool:
+    """Return whether an error carries an explicit rate-limit signal."""
+    if _extract_status_code(error) == 429:
+        return True
+
+    if _has_rate_limit_code(error):
+        return True
+
+    message = str(error or "")
+    return any(pattern.search(message) for pattern in _RATE_LIMIT_TEXT_PATTERNS)
+
+
+def _extract_status_code(error: Any) -> Optional[int]:
+    fallback = None
+    for obj in (error, _get_value(error, "response")):
+        if obj is None:
+            continue
+        for name in ("status_code", "status", "http_status", "statusCode"):
+            status_code = _to_int(_get_value(obj, name))
+            if status_code == 429:
+                return status_code
+            if fallback is None and status_code is not None:
+                fallback = status_code
+    return fallback
+
+
+def _has_rate_limit_code(error: Any) -> bool:
+    for obj in (error, _get_value(error, "response")):
+        if obj is None:
+            continue
+        for name in ("code", "error_code", "errorCode"):
+            error_code = _get_value(obj, name)
+            if (
+                error_code is not None
+                and _normalize_code(error_code) in _RATE_LIMIT_CODES
+            ):
+                return True
+    return False
+
+
+def _extract_trace_id(error: Any) -> Optional[Any]:
+    for name in ("trace_id", "traceId", "request_id", "requestId"):
+        trace_id = _get_value(error, name)
+        if trace_id:
+            return trace_id
+
+    response = _get_value(error, "response")
+    headers = _get_value(response, "headers")
+    if not headers:
+        return None
+
+    for name in ("x-acs-request-id", "x-request-id", "x-trace-id", "trace-id"):
+        trace_id = _get_header(headers, name)
+        if trace_id:
+            return trace_id
+    return None
+
+
+def _get_value(obj: Any, name: str) -> Optional[Any]:
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _get_header(headers: Any, name: str) -> Optional[Any]:
+    if isinstance(headers, dict):
+        for key, value in headers.items():
+            if str(key).lower() == name:
+                return value
+        return None
+    get = getattr(headers, "get", None)
+    if callable(get):
+        return get(name)
+    return None
+
+
+def _normalize_code(code: Any) -> str:
+    normalized = re.sub(r"[^a-z0-9]", "", str(code).lower())
+    for suffix in ("exception", "error"):
+        if normalized.endswith(suffix):
+            return normalized[: -len(suffix)]
+    return normalized
+
+
+def _to_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/agentrun/server/invoker.py
+++ b/agentrun/server/invoker.py
@@ -24,17 +24,15 @@ from typing import (
 )
 import uuid
 
-from agentrun.utils.error_utils import (
-    build_error_event_data,
-    is_rate_limited_error,
-)
+from agentrun.utils.error_utils import build_error_event_data, is_model_error
+from agentrun.utils.reasoning import get_reasoning_content
+
 from .model import AgentEvent, AgentRequest, EventType
 from .protocol import (
     AsyncInvokeAgentHandler,
     InvokeAgentHandler,
     SyncInvokeAgentHandler,
 )
-from agentrun.utils.reasoning import get_reasoning_content
 
 
 class AgentInvoker:
@@ -343,7 +341,7 @@ class AgentInvoker:
         return events
 
     def _wrap_text(self, text: str) -> AgentEvent:
-        if is_rate_limited_error(text):
+        if is_model_error(text):
             return AgentEvent(
                 event=EventType.ERROR,
                 data=build_error_event_data(

--- a/agentrun/server/invoker.py
+++ b/agentrun/server/invoker.py
@@ -24,7 +24,10 @@ from typing import (
 )
 import uuid
 
-from agentrun.utils.error_utils import build_error_event_data
+from agentrun.utils.error_utils import (
+    build_error_event_data,
+    is_rate_limited_error,
+)
 from .model import AgentEvent, AgentRequest, EventType
 from .protocol import (
     AsyncInvokeAgentHandler,
@@ -118,10 +121,7 @@ class AgentInvoker:
                     if isinstance(item, str):
                         if not item:  # 跳过空字符串
                             continue
-                        yield AgentEvent(
-                            event=EventType.TEXT,
-                            data={"delta": item},
-                        )
+                        yield self._wrap_text(item)
 
                     elif isinstance(item, AgentEvent):
                         # 处理用户返回的事件
@@ -232,12 +232,7 @@ class AgentInvoker:
             return results
 
         if isinstance(result, str):
-            results.append(
-                AgentEvent(
-                    event=EventType.TEXT,
-                    data={"delta": result},
-                )
-            )
+            results.append(self._wrap_text(result))
 
         elif isinstance(result, AgentEvent):
             # 处理可能的 TOOL_CALL 展开
@@ -248,12 +243,7 @@ class AgentInvoker:
                 if isinstance(item, AgentEvent):
                     results.extend(self._process_user_event(item))
                 elif isinstance(item, str) and item:
-                    results.append(
-                        AgentEvent(
-                            event=EventType.TEXT,
-                            data={"delta": item},
-                        )
-                    )
+                    results.append(self._wrap_text(item))
                 else:
                     results.extend(self._wrap_model_chunk(item))
 
@@ -280,10 +270,7 @@ class AgentInvoker:
             if isinstance(item, str):
                 if not item:
                     continue
-                yield AgentEvent(
-                    event=EventType.TEXT,
-                    data={"delta": item},
-                )
+                yield self._wrap_text(item)
 
             elif isinstance(item, AgentEvent):
                 for processed_event in self._process_user_event(item):
@@ -351,14 +338,24 @@ class AgentInvoker:
 
         content = self._read_attr_or_key(item, "content")
         if isinstance(content, str) and content:
-            events.append(
-                AgentEvent(
-                    event=EventType.TEXT,
-                    data={"delta": content},
-                )
-            )
+            events.append(self._wrap_text(content))
 
         return events
+
+    def _wrap_text(self, text: str) -> AgentEvent:
+        if is_rate_limited_error(text):
+            return AgentEvent(
+                event=EventType.ERROR,
+                data=build_error_event_data(
+                    text,
+                    fallback_code=type(text).__name__,
+                    fallback_message=text,
+                ),
+            )
+        return AgentEvent(
+            event=EventType.TEXT,
+            data={"delta": text},
+        )
 
     def _read_attr_or_key(self, obj: Any, key: str) -> Any:
         if isinstance(obj, dict):

--- a/agentrun/server/invoker.py
+++ b/agentrun/server/invoker.py
@@ -24,6 +24,7 @@ from typing import (
 )
 import uuid
 
+from .error_utils import build_error_event_data
 from .model import AgentEvent, AgentRequest, EventType
 from .protocol import (
     AsyncInvokeAgentHandler,
@@ -142,7 +143,11 @@ class AgentInvoker:
             logger.error(f"Agent 调用出错: {e}", exc_info=True)
             yield AgentEvent(
                 event=EventType.ERROR,
-                data={"message": str(e), "code": type(e).__name__},
+                data=build_error_event_data(
+                    e,
+                    fallback_code=type(e).__name__,
+                    fallback_message=str(e),
+                ),
             )
 
     def _process_user_event(

--- a/agentrun/server/invoker.py
+++ b/agentrun/server/invoker.py
@@ -24,7 +24,7 @@ from typing import (
 )
 import uuid
 
-from .error_utils import build_error_event_data
+from agentrun.utils.error_utils import build_error_event_data
 from .model import AgentEvent, AgentRequest, EventType
 from .protocol import (
     AsyncInvokeAgentHandler,

--- a/agentrun/utils/error_utils.py
+++ b/agentrun/utils/error_utils.py
@@ -1,43 +1,20 @@
-"""Error helpers for AgentRun event streams."""
+"""Small helpers for model rate-limit errors."""
 
 import re
 from typing import Any, Dict, Optional
 
 RATE_LIMITED_CODE = "RATE_LIMITED"
 RATE_LIMITED_RETRY_AFTER_MS = 2000
-
+_RATE_LIMIT_TEXT_RE = re.compile(
+    r"429|too[-_\s]*many[-_\s]*requests|rate[-_\s]*limit|throttl",
+    re.IGNORECASE,
+)
 _RATE_LIMIT_CODES = {
     "ratelimitexceeded",
     "ratelimited",
-    "resourcethrottled",
     "throttling",
-    "throttlingquota",
-    "throttlingratequota",
-    "throttlingexception",
     "toomanyrequests",
 }
-
-_RATE_LIMIT_TEXT_PATTERNS = [
-    re.compile(r"\btoo[-_\s]*many[-_\s]*requests\b", re.IGNORECASE),
-    re.compile(
-        r"\brate[-_\s]*limit(?:ed|[-_\s]*exceeded)\b",
-        re.IGNORECASE,
-    ),
-    re.compile(r"\bresource[-_\s]*throttled\b", re.IGNORECASE),
-    re.compile(
-        r"\b(?:throttling|throttlingexception|throttled)\b",
-        re.IGNORECASE,
-    ),
-]
-
-
-def format_error_message(error: Any) -> str:
-    """Format errors consistently with existing LangGraph conversion."""
-    if error is None:
-        return ""
-    if isinstance(error, Exception):
-        return f"{type(error).__name__}: {str(error)}"
-    return str(error)
 
 
 def build_error_event_data(
@@ -46,7 +23,7 @@ def build_error_event_data(
     fallback_code: str,
     fallback_message: str,
 ) -> Dict[str, Any]:
-    """Build AgentEvent ERROR data, normalizing model rate limits."""
+    """Keep the original message; add rate-limit metadata only when matched."""
     if not is_rate_limited_error(error):
         return {"message": fallback_message, "code": fallback_code}
 
@@ -56,68 +33,40 @@ def build_error_event_data(
         "retryable": True,
         "retryAfterMs": RATE_LIMITED_RETRY_AFTER_MS,
     }
-    trace_id = _extract_trace_id(error)
+    trace_id = _get_value(error, "trace_id") or _get_value(error, "traceId")
     if trace_id:
         data["traceId"] = str(trace_id)
     return data
 
 
 def is_rate_limited_error(error: Any) -> bool:
-    """Return whether an error carries an explicit rate-limit signal."""
-    if _extract_status_code(error) == 429:
+    if error is None:
+        return False
+    if _status_code(error) == 429 or _status_code(_get_value(error, "response")) == 429:
         return True
-
-    if _has_rate_limit_code(error):
+    if _rate_limit_code(error) or _rate_limit_code(_get_value(error, "response")):
         return True
-
-    message = str(error or "")
-    return any(pattern.search(message) for pattern in _RATE_LIMIT_TEXT_PATTERNS)
+    return bool(_RATE_LIMIT_TEXT_RE.search(str(error)))
 
 
-def _extract_status_code(error: Any) -> Optional[int]:
-    fallback = None
-    for obj in (error, _get_value(error, "response")):
-        if obj is None:
+def _status_code(obj: Any) -> Optional[int]:
+    for name in ("status_code", "status", "http_status", "statusCode"):
+        value = _get_value(obj, name)
+        if value is None:
             continue
-        for name in ("status_code", "status", "http_status", "statusCode"):
-            status_code = _to_int(_get_value(obj, name))
-            if status_code == 429:
-                return status_code
-            if fallback is None and status_code is not None:
-                fallback = status_code
-    return fallback
-
-
-def _has_rate_limit_code(error: Any) -> bool:
-    for obj in (error, _get_value(error, "response")):
-        if obj is None:
-            continue
-        for name in ("code", "error_code", "errorCode"):
-            error_code = _get_value(obj, name)
-            if (
-                error_code is not None
-                and _normalize_code(error_code) in _RATE_LIMIT_CODES
-            ):
-                return True
-    return False
-
-
-def _extract_trace_id(error: Any) -> Optional[Any]:
-    for name in ("trace_id", "traceId", "request_id", "requestId"):
-        trace_id = _get_value(error, name)
-        if trace_id:
-            return trace_id
-
-    response = _get_value(error, "response")
-    headers = _get_value(response, "headers")
-    if not headers:
-        return None
-
-    for name in ("x-acs-request-id", "x-request-id", "x-trace-id", "trace-id"):
-        trace_id = _get_header(headers, name)
-        if trace_id:
-            return trace_id
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
     return None
+
+
+def _rate_limit_code(obj: Any) -> bool:
+    for name in ("code", "error_code", "errorCode"):
+        code = _get_value(obj, name)
+        if code and _normalize_code(code) in _RATE_LIMIT_CODES:
+            return True
+    return False
 
 
 def _get_value(obj: Any, name: str) -> Optional[Any]:
@@ -128,31 +77,9 @@ def _get_value(obj: Any, name: str) -> Optional[Any]:
     return getattr(obj, name, None)
 
 
-def _get_header(headers: Any, name: str) -> Optional[Any]:
-    target = str(name).lower()
-    if isinstance(headers, dict):
-        for key, value in headers.items():
-            if str(key).lower() == target:
-                return value
-        return None
-    get = getattr(headers, "get", None)
-    if callable(get):
-        return get(name)
-    return None
-
-
 def _normalize_code(code: Any) -> str:
-    normalized = re.sub(r"[^a-z0-9]", "", str(code).lower())
+    value = "".join(ch for ch in str(code).lower() if ch.isalnum())
     for suffix in ("exception", "error"):
-        if normalized.endswith(suffix):
-            return normalized[: -len(suffix)]
-    return normalized
-
-
-def _to_int(value: Any) -> Optional[int]:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
+        if value.endswith(suffix):
+            return value[: -len(suffix)]
+    return value

--- a/agentrun/utils/error_utils.py
+++ b/agentrun/utils/error_utils.py
@@ -1,4 +1,4 @@
-"""Error helpers for AgentRun server streams."""
+"""Error helpers for AgentRun event streams."""
 
 import re
 from typing import Any, Dict, Optional
@@ -25,9 +25,8 @@ _RATE_LIMIT_TEXT_PATTERNS = [
         re.IGNORECASE,
     ),
     re.compile(r"\bresource[-_\s]*throttled\b", re.IGNORECASE),
-    re.compile(r"\bthrottling(?:exception| exception| error)\b", re.IGNORECASE),
     re.compile(
-        r"\b(?:http|status|status code|code)\s*[:=]?\s*429\b",
+        r"\b(?:throttling|throttlingexception|throttled)\b",
         re.IGNORECASE,
     ),
 ]

--- a/agentrun/utils/error_utils.py
+++ b/agentrun/utils/error_utils.py
@@ -1,20 +1,143 @@
-"""Small helpers for model rate-limit errors."""
+"""Small helpers for model-side errors."""
 
+from dataclasses import dataclass
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 RATE_LIMITED_CODE = "RATE_LIMITED"
 RATE_LIMITED_RETRY_AFTER_MS = 2000
+_KNOWN_STATUS_CODES = (400, 401, 403, 429, 500, 503)
+_HTTP_STATUS_TEXT_RE = re.compile(
+    r"(?:error\s+code|status\s+code|http\s+status|http)"
+    r"\D{0,20}(400|401|403|429|500|503)\b"
+    r"|\b(400|401|403|429|500|503)\s*(?:[-:—]|$)",
+    re.IGNORECASE,
+)
 _RATE_LIMIT_TEXT_RE = re.compile(
     r"429|too[-_\s]*many[-_\s]*requests|rate[-_\s]*limit|throttl",
     re.IGNORECASE,
 )
-_RATE_LIMIT_CODES = {
-    "ratelimitexceeded",
-    "ratelimited",
-    "throttling",
-    "toomanyrequests",
+
+
+@dataclass(frozen=True)
+class _ModelErrorSpec:
+    code: str
+    status_code: int
+    retryable: bool = False
+    retry_after_ms: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ModelErrorInfo:
+    code: str
+    status_code: Optional[int] = None
+    provider_code: Optional[str] = None
+    retryable: bool = False
+    retry_after_ms: Optional[int] = None
+
+
+_RATE_LIMIT_SPEC = _ModelErrorSpec(
+    RATE_LIMITED_CODE,
+    429,
+    retryable=True,
+    retry_after_ms=RATE_LIMITED_RETRY_AFTER_MS,
+)
+_MODEL_ERROR_SPECS = {
+    "arrearage": _ModelErrorSpec("MODEL_ARREARAGE", 400),
+    "datainspectionfailed": _ModelErrorSpec(
+        "MODEL_DATA_INSPECTION_FAILED", 400
+    ),
+    "invalidapikey": _ModelErrorSpec("MODEL_AUTHENTICATION_ERROR", 401),
+    "authentication": _ModelErrorSpec("MODEL_AUTHENTICATION_ERROR", 401),
+    "accessdenied": _ModelErrorSpec("MODEL_ACCESS_DENIED", 403),
+    "accessdeniedunpurchased": _ModelErrorSpec("MODEL_ACCESS_DENIED", 403),
+    "modelaccessdenied": _ModelErrorSpec("MODEL_ACCESS_DENIED", 403),
+    "workspaceaccessdenied": _ModelErrorSpec("MODEL_ACCESS_DENIED", 403),
+    "throttling": _RATE_LIMIT_SPEC,
+    "throttlingratequota": _RATE_LIMIT_SPEC,
+    "throttlingallocationquota": _RATE_LIMIT_SPEC,
+    "limitrequests": _RATE_LIMIT_SPEC,
+    "ratelimit": _RATE_LIMIT_SPEC,
+    "ratelimitexceeded": _RATE_LIMIT_SPEC,
+    "ratelimited": _RATE_LIMIT_SPEC,
+    "toomanyrequests": _RATE_LIMIT_SPEC,
+    "internal": _ModelErrorSpec("MODEL_INTERNAL_ERROR", 500, retryable=True),
+    "internalerroralgo": _ModelErrorSpec(
+        "MODEL_INTERNAL_ERROR", 500, retryable=True
+    ),
+    "system": _ModelErrorSpec("MODEL_INTERNAL_ERROR", 500, retryable=True),
+    "modelserving": _ModelErrorSpec(
+        "MODEL_SERVICE_UNAVAILABLE", 503, retryable=True
+    ),
+    "serviceunavailable": _ModelErrorSpec(
+        "MODEL_SERVICE_UNAVAILABLE", 503, retryable=True
+    ),
 }
+_STATUS_CODE_SPECS = {
+    400: _ModelErrorSpec("MODEL_BAD_REQUEST", 400),
+    401: _ModelErrorSpec("MODEL_AUTHENTICATION_ERROR", 401),
+    403: _ModelErrorSpec("MODEL_ACCESS_DENIED", 403),
+    429: _RATE_LIMIT_SPEC,
+    500: _ModelErrorSpec("MODEL_INTERNAL_ERROR", 500, retryable=True),
+    503: _ModelErrorSpec("MODEL_SERVICE_UNAVAILABLE", 503, retryable=True),
+}
+_TEXT_PROVIDER_PATTERNS: Tuple[Tuple[re.Pattern[str], Optional[str]], ...] = (
+    (re.compile(r"\bArrearage\b", re.IGNORECASE), "Arrearage"),
+    (
+        re.compile(
+            r"access\s+denied.*account.*good\s+standing",
+            re.IGNORECASE,
+        ),
+        "Arrearage",
+    ),
+    (
+        re.compile(
+            r"\bDataInspectionFailed\b|\bdata[_-]inspection[_-]failed\b",
+            re.IGNORECASE,
+        ),
+        "DataInspectionFailed",
+    ),
+    (re.compile(r"\bInvalidApiKey\b", re.IGNORECASE), None),
+    (
+        re.compile(r"\bAuthenticationError\b", re.IGNORECASE),
+        None,
+    ),
+    (
+        re.compile(r"\bModel\.AccessDenied\b", re.IGNORECASE),
+        None,
+    ),
+    (
+        re.compile(r"\bAccessDenied\.Unpurchased\b", re.IGNORECASE),
+        None,
+    ),
+    (re.compile(r"\bAccessDenied\b", re.IGNORECASE), None),
+    (
+        re.compile(r"\bWorkspaceAccessDenied\b", re.IGNORECASE),
+        None,
+    ),
+    (
+        re.compile(
+            r"\bThrottling(?:\.(?:RateQuota|AllocationQuota))?\b",
+            re.IGNORECASE,
+        ),
+        None,
+    ),
+    (re.compile(r"\bLimitRequests\b", re.IGNORECASE), None),
+    (re.compile(r"\bRateLimit\b", re.IGNORECASE), None),
+    (
+        re.compile(r"\bInternalError(?:\.Algo)?\b", re.IGNORECASE),
+        None,
+    ),
+    (re.compile(r"\bSystemError\b", re.IGNORECASE), None),
+    (
+        re.compile(r"\bModelServingError\b", re.IGNORECASE),
+        None,
+    ),
+    (
+        re.compile(r"\bServiceUnavailable\b", re.IGNORECASE),
+        None,
+    ),
+)
 
 
 def build_error_event_data(
@@ -23,58 +146,191 @@ def build_error_event_data(
     fallback_code: str,
     fallback_message: str,
 ) -> Dict[str, Any]:
-    """Keep the original message; add rate-limit metadata only when matched."""
-    if not is_rate_limited_error(error):
+    """Keep the original message; add model-error metadata when matched."""
+    model_error = classify_model_error(error)
+    if model_error is None:
         return {"message": fallback_message, "code": fallback_code}
 
     data: Dict[str, Any] = {
         "message": fallback_message,
-        "code": RATE_LIMITED_CODE,
-        "retryable": True,
-        "retryAfterMs": RATE_LIMITED_RETRY_AFTER_MS,
+        "code": model_error.code,
     }
-    trace_id = _get_value(error, "trace_id") or _get_value(error, "traceId")
+    if model_error.retryable:
+        data["retryable"] = True
+    if model_error.retry_after_ms is not None:
+        data["retryAfterMs"] = model_error.retry_after_ms
+    if model_error.status_code is not None:
+        data["statusCode"] = model_error.status_code
+    if model_error.provider_code:
+        data["providerCode"] = model_error.provider_code
+    trace_id = _first_value(error, "trace_id", "traceId")
     if trace_id:
         data["traceId"] = str(trace_id)
+    request_id = _first_value(error, "request_id", "requestId")
+    if request_id:
+        data["requestId"] = str(request_id)
     return data
 
 
-def is_rate_limited_error(error: Any) -> bool:
+def classify_model_error(error: Any) -> Optional[ModelErrorInfo]:
     if error is None:
-        return False
-    if _status_code(error) == 429 or _status_code(_get_value(error, "response")) == 429:
-        return True
-    if _rate_limit_code(error) or _rate_limit_code(_get_value(error, "response")):
-        return True
-    return bool(_RATE_LIMIT_TEXT_RE.search(str(error)))
+        return None
 
+    status_code = _status_code(error)
+    provider_code = _provider_code(error)
+    spec = _spec_from_provider_code(provider_code)
+    if spec is not None:
+        return _to_model_error_info(spec, status_code, provider_code)
 
-def _status_code(obj: Any) -> Optional[int]:
-    for name in ("status_code", "status", "http_status", "statusCode"):
-        value = _get_value(obj, name)
-        if value is None:
-            continue
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
+    text = str(error)
+    provider_code = _provider_code_from_text(text)
+    spec = _spec_from_provider_code(provider_code)
+    if spec is not None:
+        return _to_model_error_info(
+            spec,
+            status_code or _status_code_from_text(text),
+            provider_code,
+        )
+
+    if status_code in _STATUS_CODE_SPECS:
+        return _to_model_error_info(
+            _STATUS_CODE_SPECS[status_code], status_code
+        )
+
+    if _RATE_LIMIT_TEXT_RE.search(text):
+        return _to_model_error_info(_RATE_LIMIT_SPEC, status_code)
+
     return None
 
 
-def _rate_limit_code(obj: Any) -> bool:
-    for name in ("code", "error_code", "errorCode"):
-        code = _get_value(obj, name)
-        if code and _normalize_code(code) in _RATE_LIMIT_CODES:
-            return True
-    return False
+def is_model_error(error: Any) -> bool:
+    return classify_model_error(error) is not None
+
+
+def is_rate_limited_error(error: Any) -> bool:
+    model_error = classify_model_error(error)
+    return bool(model_error and model_error.code == RATE_LIMITED_CODE)
+
+
+def _to_model_error_info(
+    spec: _ModelErrorSpec,
+    status_code: Optional[int],
+    provider_code: Optional[str] = None,
+) -> ModelErrorInfo:
+    return ModelErrorInfo(
+        code=spec.code,
+        status_code=status_code or spec.status_code,
+        provider_code=provider_code,
+        retryable=spec.retryable,
+        retry_after_ms=spec.retry_after_ms,
+    )
+
+
+def _spec_from_provider_code(
+    provider_code: Optional[str],
+) -> Optional[_ModelErrorSpec]:
+    if not provider_code:
+        return None
+    return _MODEL_ERROR_SPECS.get(_normalize_code(provider_code))
+
+
+def _status_code(obj: Any) -> Optional[int]:
+    for part in _iter_error_parts(obj):
+        for name in ("status_code", "status", "http_status", "statusCode"):
+            value = _get_value(part, name)
+            if value is None:
+                continue
+            try:
+                status_code = int(value)
+            except (TypeError, ValueError):
+                continue
+            if status_code in _KNOWN_STATUS_CODES:
+                return status_code
+    return None
+
+
+def _status_code_from_text(text: str) -> Optional[int]:
+    match = _HTTP_STATUS_TEXT_RE.search(text)
+    if not match:
+        return None
+    for value in match.groups():
+        if value:
+            return int(value)
+    return None
+
+
+def _provider_code(obj: Any) -> Optional[str]:
+    for part in _iter_error_parts(obj):
+        for name in ("code", "error_code", "errorCode"):
+            code = _get_value(part, name)
+            if code is None or isinstance(code, (dict, list, tuple)):
+                continue
+            value = str(code)
+            if not value.isdigit():
+                return value
+    return None
+
+
+def _provider_code_from_text(text: str) -> Optional[str]:
+    for pattern, provider_code in _TEXT_PROVIDER_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return provider_code or match.group(0)
+    return None
+
+
+def _iter_error_parts(obj: Any) -> Iterator[Any]:
+    parts = [obj]
+    seen = set()
+    index = 0
+    while index < len(parts) and index < 20:
+        part = parts[index]
+        index += 1
+        if part is None or id(part) in seen:
+            continue
+        seen.add(id(part))
+        yield part
+        for name in ("response", "body", "data", "error"):
+            value = _get_value(part, name)
+            if value is not None and value is not part:
+                parts.append(value)
+        json_body = _json_body(part)
+        if json_body is not None and json_body is not part:
+            parts.append(json_body)
+
+
+def _json_body(obj: Any) -> Optional[Any]:
+    json_method = getattr(obj, "json", None)
+    if not callable(json_method):
+        return None
+    try:
+        return json_method()
+    except Exception:
+        return None
 
 
 def _get_value(obj: Any, name: str) -> Optional[Any]:
     if obj is None:
         return None
     if isinstance(obj, dict):
-        return obj.get(name)
+        value = obj.get(name)
+        if value is not None:
+            return value
+        lower_name = name.lower()
+        for key, value in obj.items():
+            if isinstance(key, str) and key.lower() == lower_name:
+                return value
+        return None
     return getattr(obj, name, None)
+
+
+def _first_value(obj: Any, *names: str) -> Optional[Any]:
+    for part in _iter_error_parts(obj):
+        for name in names:
+            value = _get_value(part, name)
+            if value:
+                return value
+    return None
 
 
 def _normalize_code(code: Any) -> str:

--- a/agentrun/utils/error_utils.py
+++ b/agentrun/utils/error_utils.py
@@ -4,7 +4,6 @@ import re
 from typing import Any, Dict, Optional
 
 RATE_LIMITED_CODE = "RATE_LIMITED"
-RATE_LIMITED_MESSAGE = "模型当前请求过多，请稍后再试"
 RATE_LIMITED_RETRY_AFTER_MS = 2000
 
 _RATE_LIMIT_CODES = {
@@ -52,7 +51,7 @@ def build_error_event_data(
         return {"message": fallback_message, "code": fallback_code}
 
     data: Dict[str, Any] = {
-        "message": RATE_LIMITED_MESSAGE,
+        "message": fallback_message,
         "code": RATE_LIMITED_CODE,
         "retryable": True,
         "retryAfterMs": RATE_LIMITED_RETRY_AFTER_MS,

--- a/tests/unittests/integration/test_langgraph_events.py
+++ b/tests/unittests/integration/test_langgraph_events.py
@@ -842,7 +842,7 @@ class TestErrorEvents:
 
         assert len(results) == 1
         assert results[0].event == EventType.ERROR
-        assert results[0].data["message"] == "模型当前请求过多，请稍后再试"
+        assert results[0].data["message"] == "LLM error: RuntimeError: API rate limit exceeded"
         assert results[0].data["code"] == "RATE_LIMITED"
         assert results[0].data["retryable"] is True
         assert results[0].data["retryAfterMs"] == 2000

--- a/tests/unittests/integration/test_langgraph_events.py
+++ b/tests/unittests/integration/test_langgraph_events.py
@@ -11,10 +11,8 @@
 边界事件（如 TOOL_CALL_START/END）由协议层自动生成，转换器不再输出这些事件。
 """
 
-from typing import Dict, List, Union
+from typing import Dict
 from unittest.mock import MagicMock
-
-import pytest
 
 from agentrun.integration.langgraph import AgentRunConverter
 from agentrun.server.model import AgentEvent, EventType
@@ -555,7 +553,7 @@ class TestAgentRunConverterClass:
             },
         }
 
-        results1 = list(converter.convert(event1))
+        list(converter.convert(event1))
         assert converter._tool_call_id_map[0] == "call_stateful"
 
         # 第二个 chunk 使用映射
@@ -842,10 +840,40 @@ class TestErrorEvents:
 
         assert len(results) == 1
         assert results[0].event == EventType.ERROR
-        assert results[0].data["message"] == "RuntimeError: Error code: 429 - rate limit exceeded"
+        assert (
+            results[0].data["message"]
+            == "RuntimeError: Error code: 429 - rate limit exceeded"
+        )
         assert results[0].data["code"] == "RATE_LIMITED"
         assert results[0].data["retryable"] is True
         assert results[0].data["retryAfterMs"] == 2000
+
+    def test_on_llm_error_model_service_unavailable(self):
+        """测试 on_llm_error 模型服务不可用错误归一化"""
+
+        class ModelError(RuntimeError):
+            status_code = 503
+            code = "ModelServingError"
+            request_id = "req-503"
+
+        event = {
+            "event": "on_llm_error",
+            "run_id": "run_llm",
+            "data": {
+                "error": ModelError("model overloaded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["message"] == "ModelError: model overloaded"
+        assert results[0].data["code"] == "MODEL_SERVICE_UNAVAILABLE"
+        assert results[0].data["retryable"] is True
+        assert results[0].data["statusCode"] == 503
+        assert results[0].data["providerCode"] == "ModelServingError"
+        assert results[0].data["requestId"] == "req-503"
 
     def test_on_chain_error(self):
         """测试 on_chain_error 事件

--- a/tests/unittests/integration/test_langgraph_events.py
+++ b/tests/unittests/integration/test_langgraph_events.py
@@ -890,6 +890,29 @@ class TestErrorEvents:
         assert "KeyError" in results[0].data["message"]
         assert results[0].data["code"] == "CHAIN_ERROR"
 
+    def test_on_chain_error_status_429_keeps_chain_error(self):
+        """测试 chain 429 不套用模型限流语义"""
+
+        class ChainStatusError(RuntimeError):
+            status_code = 429
+
+        event = {
+            "event": "on_chain_error",
+            "name": "agent_chain",
+            "run_id": "run_chain",
+            "data": {
+                "error": ChainStatusError("chain quota exceeded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["code"] == "CHAIN_ERROR"
+        assert "retryable" not in results[0].data
+        assert "retryAfterMs" not in results[0].data
+
     def test_on_retriever_error(self):
         """测试 on_retriever_error 事件
 
@@ -912,6 +935,29 @@ class TestErrorEvents:
         assert "vector_store" in results[0].data["message"]
         assert "ConnectionError" in results[0].data["message"]
         assert results[0].data["code"] == "RETRIEVER_ERROR"
+
+    def test_on_retriever_error_status_429_keeps_retriever_error(self):
+        """测试 retriever 429 不套用模型限流语义"""
+
+        class RetrieverStatusError(RuntimeError):
+            status_code = 429
+
+        event = {
+            "event": "on_retriever_error",
+            "name": "vector_store",
+            "run_id": "run_retriever",
+            "data": {
+                "error": RetrieverStatusError("retriever quota exceeded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["code"] == "RETRIEVER_ERROR"
+        assert "retryable" not in results[0].data
+        assert "retryAfterMs" not in results[0].data
 
     def test_tool_error_in_complete_flow(self):
         """测试完整流程中的工具错误

--- a/tests/unittests/integration/test_langgraph_events.py
+++ b/tests/unittests/integration/test_langgraph_events.py
@@ -816,7 +816,7 @@ class TestErrorEvents:
             "event": "on_llm_error",
             "run_id": "run_llm",
             "data": {
-                "error": RuntimeError("API rate limit exceeded"),
+                "error": RuntimeError("Model backend failed"),
             },
         }
 
@@ -827,6 +827,45 @@ class TestErrorEvents:
         assert "LLM error" in results[0].data["message"]
         assert "RuntimeError" in results[0].data["message"]
         assert results[0].data["code"] == "LLM_ERROR"
+
+    def test_on_llm_error_rate_limited(self):
+        """测试 on_llm_error 限流错误归一化"""
+        event = {
+            "event": "on_llm_error",
+            "run_id": "run_llm",
+            "data": {
+                "error": RuntimeError("API rate limit exceeded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["message"] == "模型当前请求过多，请稍后再试"
+        assert results[0].data["code"] == "RATE_LIMITED"
+        assert results[0].data["retryable"] is True
+        assert results[0].data["retryAfterMs"] == 2000
+
+    def test_on_llm_error_rate_limit_text_false_positive(self):
+        """测试说明性 rate limit/429 文本不会误判"""
+        event = {
+            "event": "on_llm_error",
+            "run_id": "run_llm",
+            "data": {
+                "error": RuntimeError(
+                    "ticket 429 mentions rate limit dashboard, auth failed"
+                ),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["code"] == "LLM_ERROR"
+        assert "retryable" not in results[0].data
+        assert "retryAfterMs" not in results[0].data
 
     def test_on_chain_error(self):
         """测试 on_chain_error 事件

--- a/tests/unittests/integration/test_langgraph_events.py
+++ b/tests/unittests/integration/test_langgraph_events.py
@@ -829,12 +829,12 @@ class TestErrorEvents:
         assert results[0].data["code"] == "LLM_ERROR"
 
     def test_on_llm_error_rate_limited(self):
-        """测试 on_llm_error 限流错误归一化"""
+        """测试 on_llm_error 限流错误归一化且 message 保留原始错误"""
         event = {
             "event": "on_llm_error",
             "run_id": "run_llm",
             "data": {
-                "error": RuntimeError("API rate limit exceeded"),
+                "error": RuntimeError("Error code: 429 - rate limit exceeded"),
             },
         }
 
@@ -842,30 +842,10 @@ class TestErrorEvents:
 
         assert len(results) == 1
         assert results[0].event == EventType.ERROR
-        assert results[0].data["message"] == "LLM error: RuntimeError: API rate limit exceeded"
+        assert results[0].data["message"] == "RuntimeError: Error code: 429 - rate limit exceeded"
         assert results[0].data["code"] == "RATE_LIMITED"
         assert results[0].data["retryable"] is True
         assert results[0].data["retryAfterMs"] == 2000
-
-    def test_on_llm_error_rate_limit_text_false_positive(self):
-        """测试说明性 rate limit/429 文本不会误判"""
-        event = {
-            "event": "on_llm_error",
-            "run_id": "run_llm",
-            "data": {
-                "error": RuntimeError(
-                    "ticket 429 mentions rate limit dashboard, auth failed"
-                ),
-            },
-        }
-
-        results = list(AgentRunConverter().to_agui_events(event))
-
-        assert len(results) == 1
-        assert results[0].event == EventType.ERROR
-        assert results[0].data["code"] == "LLM_ERROR"
-        assert "retryable" not in results[0].data
-        assert "retryAfterMs" not in results[0].data
 
     def test_on_chain_error(self):
         """测试 on_chain_error 事件
@@ -890,29 +870,6 @@ class TestErrorEvents:
         assert "KeyError" in results[0].data["message"]
         assert results[0].data["code"] == "CHAIN_ERROR"
 
-    def test_on_chain_error_status_429_keeps_chain_error(self):
-        """测试 chain 429 不套用模型限流语义"""
-
-        class ChainStatusError(RuntimeError):
-            status_code = 429
-
-        event = {
-            "event": "on_chain_error",
-            "name": "agent_chain",
-            "run_id": "run_chain",
-            "data": {
-                "error": ChainStatusError("chain quota exceeded"),
-            },
-        }
-
-        results = list(AgentRunConverter().to_agui_events(event))
-
-        assert len(results) == 1
-        assert results[0].event == EventType.ERROR
-        assert results[0].data["code"] == "CHAIN_ERROR"
-        assert "retryable" not in results[0].data
-        assert "retryAfterMs" not in results[0].data
-
     def test_on_retriever_error(self):
         """测试 on_retriever_error 事件
 
@@ -935,29 +892,6 @@ class TestErrorEvents:
         assert "vector_store" in results[0].data["message"]
         assert "ConnectionError" in results[0].data["message"]
         assert results[0].data["code"] == "RETRIEVER_ERROR"
-
-    def test_on_retriever_error_status_429_keeps_retriever_error(self):
-        """测试 retriever 429 不套用模型限流语义"""
-
-        class RetrieverStatusError(RuntimeError):
-            status_code = 429
-
-        event = {
-            "event": "on_retriever_error",
-            "name": "vector_store",
-            "run_id": "run_retriever",
-            "data": {
-                "error": RetrieverStatusError("retriever quota exceeded"),
-            },
-        }
-
-        results = list(AgentRunConverter().to_agui_events(event))
-
-        assert len(results) == 1
-        assert results[0].event == EventType.ERROR
-        assert results[0].data["code"] == "RETRIEVER_ERROR"
-        assert "retryable" not in results[0].data
-        assert "retryAfterMs" not in results[0].data
 
     def test_tool_error_in_complete_flow(self):
         """测试完整流程中的工具错误

--- a/tests/unittests/integration/test_langgraph_to_agent_event.py
+++ b/tests/unittests/integration/test_langgraph_to_agent_event.py
@@ -840,7 +840,7 @@ class TestErrorEvents:
 
         assert len(results) == 1
         assert results[0].event == EventType.ERROR
-        assert results[0].data["message"] == "模型当前请求过多，请稍后再试"
+        assert results[0].data["message"] == "LLM error: RuntimeError: API rate limit exceeded"
         assert results[0].data["code"] == "RATE_LIMITED"
         assert results[0].data["retryable"] is True
         assert results[0].data["retryAfterMs"] == 2000

--- a/tests/unittests/integration/test_langgraph_to_agent_event.py
+++ b/tests/unittests/integration/test_langgraph_to_agent_event.py
@@ -827,12 +827,12 @@ class TestErrorEvents:
         assert results[0].data["code"] == "LLM_ERROR"
 
     def test_on_llm_error_rate_limited(self):
-        """测试 on_llm_error 限流错误归一化"""
+        """测试 on_llm_error 限流错误归一化且 message 保留原始错误"""
         event = {
             "event": "on_llm_error",
             "run_id": "run_llm",
             "data": {
-                "error": RuntimeError("API rate limit exceeded"),
+                "error": RuntimeError("Error code: 429 - rate limit exceeded"),
             },
         }
 
@@ -840,30 +840,10 @@ class TestErrorEvents:
 
         assert len(results) == 1
         assert results[0].event == EventType.ERROR
-        assert results[0].data["message"] == "LLM error: RuntimeError: API rate limit exceeded"
+        assert results[0].data["message"] == "RuntimeError: Error code: 429 - rate limit exceeded"
         assert results[0].data["code"] == "RATE_LIMITED"
         assert results[0].data["retryable"] is True
         assert results[0].data["retryAfterMs"] == 2000
-
-    def test_on_llm_error_rate_limit_text_false_positive(self):
-        """测试说明性 rate limit/429 文本不会误判"""
-        event = {
-            "event": "on_llm_error",
-            "run_id": "run_llm",
-            "data": {
-                "error": RuntimeError(
-                    "ticket 429 mentions rate limit dashboard, auth failed"
-                ),
-            },
-        }
-
-        results = list(AgentRunConverter().to_agui_events(event))
-
-        assert len(results) == 1
-        assert results[0].event == EventType.ERROR
-        assert results[0].data["code"] == "LLM_ERROR"
-        assert "retryable" not in results[0].data
-        assert "retryAfterMs" not in results[0].data
 
     def test_on_chain_error(self):
         """测试 on_chain_error 事件
@@ -888,29 +868,6 @@ class TestErrorEvents:
         assert "KeyError" in results[0].data["message"]
         assert results[0].data["code"] == "CHAIN_ERROR"
 
-    def test_on_chain_error_status_429_keeps_chain_error(self):
-        """测试 chain 429 不套用模型限流语义"""
-
-        class ChainStatusError(RuntimeError):
-            status_code = 429
-
-        event = {
-            "event": "on_chain_error",
-            "name": "agent_chain",
-            "run_id": "run_chain",
-            "data": {
-                "error": ChainStatusError("chain quota exceeded"),
-            },
-        }
-
-        results = list(AgentRunConverter().to_agui_events(event))
-
-        assert len(results) == 1
-        assert results[0].event == EventType.ERROR
-        assert results[0].data["code"] == "CHAIN_ERROR"
-        assert "retryable" not in results[0].data
-        assert "retryAfterMs" not in results[0].data
-
     def test_on_retriever_error(self):
         """测试 on_retriever_error 事件
 
@@ -933,29 +890,6 @@ class TestErrorEvents:
         assert "vector_store" in results[0].data["message"]
         assert "ConnectionError" in results[0].data["message"]
         assert results[0].data["code"] == "RETRIEVER_ERROR"
-
-    def test_on_retriever_error_status_429_keeps_retriever_error(self):
-        """测试 retriever 429 不套用模型限流语义"""
-
-        class RetrieverStatusError(RuntimeError):
-            status_code = 429
-
-        event = {
-            "event": "on_retriever_error",
-            "name": "vector_store",
-            "run_id": "run_retriever",
-            "data": {
-                "error": RetrieverStatusError("retriever quota exceeded"),
-            },
-        }
-
-        results = list(AgentRunConverter().to_agui_events(event))
-
-        assert len(results) == 1
-        assert results[0].event == EventType.ERROR
-        assert results[0].data["code"] == "RETRIEVER_ERROR"
-        assert "retryable" not in results[0].data
-        assert "retryAfterMs" not in results[0].data
 
     def test_tool_error_in_complete_flow(self):
         """测试完整流程中的工具错误

--- a/tests/unittests/integration/test_langgraph_to_agent_event.py
+++ b/tests/unittests/integration/test_langgraph_to_agent_event.py
@@ -888,6 +888,29 @@ class TestErrorEvents:
         assert "KeyError" in results[0].data["message"]
         assert results[0].data["code"] == "CHAIN_ERROR"
 
+    def test_on_chain_error_status_429_keeps_chain_error(self):
+        """测试 chain 429 不套用模型限流语义"""
+
+        class ChainStatusError(RuntimeError):
+            status_code = 429
+
+        event = {
+            "event": "on_chain_error",
+            "name": "agent_chain",
+            "run_id": "run_chain",
+            "data": {
+                "error": ChainStatusError("chain quota exceeded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["code"] == "CHAIN_ERROR"
+        assert "retryable" not in results[0].data
+        assert "retryAfterMs" not in results[0].data
+
     def test_on_retriever_error(self):
         """测试 on_retriever_error 事件
 
@@ -910,6 +933,29 @@ class TestErrorEvents:
         assert "vector_store" in results[0].data["message"]
         assert "ConnectionError" in results[0].data["message"]
         assert results[0].data["code"] == "RETRIEVER_ERROR"
+
+    def test_on_retriever_error_status_429_keeps_retriever_error(self):
+        """测试 retriever 429 不套用模型限流语义"""
+
+        class RetrieverStatusError(RuntimeError):
+            status_code = 429
+
+        event = {
+            "event": "on_retriever_error",
+            "name": "vector_store",
+            "run_id": "run_retriever",
+            "data": {
+                "error": RetrieverStatusError("retriever quota exceeded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["code"] == "RETRIEVER_ERROR"
+        assert "retryable" not in results[0].data
+        assert "retryAfterMs" not in results[0].data
 
     def test_tool_error_in_complete_flow(self):
         """测试完整流程中的工具错误

--- a/tests/unittests/integration/test_langgraph_to_agent_event.py
+++ b/tests/unittests/integration/test_langgraph_to_agent_event.py
@@ -553,7 +553,7 @@ class TestAgentRunConverterClass:
             },
         }
 
-        results1 = list(converter.convert(event1))
+        list(converter.convert(event1))
         assert converter._tool_call_id_map[0] == "call_stateful"
 
         # 第二个 chunk 使用映射
@@ -840,10 +840,40 @@ class TestErrorEvents:
 
         assert len(results) == 1
         assert results[0].event == EventType.ERROR
-        assert results[0].data["message"] == "RuntimeError: Error code: 429 - rate limit exceeded"
+        assert (
+            results[0].data["message"]
+            == "RuntimeError: Error code: 429 - rate limit exceeded"
+        )
         assert results[0].data["code"] == "RATE_LIMITED"
         assert results[0].data["retryable"] is True
         assert results[0].data["retryAfterMs"] == 2000
+
+    def test_on_llm_error_model_service_unavailable(self):
+        """测试 on_llm_error 模型服务不可用错误归一化"""
+
+        class ModelError(RuntimeError):
+            status_code = 503
+            code = "ModelServingError"
+            request_id = "req-503"
+
+        event = {
+            "event": "on_llm_error",
+            "run_id": "run_llm",
+            "data": {
+                "error": ModelError("model overloaded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["message"] == "ModelError: model overloaded"
+        assert results[0].data["code"] == "MODEL_SERVICE_UNAVAILABLE"
+        assert results[0].data["retryable"] is True
+        assert results[0].data["statusCode"] == 503
+        assert results[0].data["providerCode"] == "ModelServingError"
+        assert results[0].data["requestId"] == "req-503"
 
     def test_on_chain_error(self):
         """测试 on_chain_error 事件

--- a/tests/unittests/integration/test_langgraph_to_agent_event.py
+++ b/tests/unittests/integration/test_langgraph_to_agent_event.py
@@ -814,7 +814,7 @@ class TestErrorEvents:
             "event": "on_llm_error",
             "run_id": "run_llm",
             "data": {
-                "error": RuntimeError("API rate limit exceeded"),
+                "error": RuntimeError("Model backend failed"),
             },
         }
 
@@ -825,6 +825,45 @@ class TestErrorEvents:
         assert "LLM error" in results[0].data["message"]
         assert "RuntimeError" in results[0].data["message"]
         assert results[0].data["code"] == "LLM_ERROR"
+
+    def test_on_llm_error_rate_limited(self):
+        """测试 on_llm_error 限流错误归一化"""
+        event = {
+            "event": "on_llm_error",
+            "run_id": "run_llm",
+            "data": {
+                "error": RuntimeError("API rate limit exceeded"),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["message"] == "模型当前请求过多，请稍后再试"
+        assert results[0].data["code"] == "RATE_LIMITED"
+        assert results[0].data["retryable"] is True
+        assert results[0].data["retryAfterMs"] == 2000
+
+    def test_on_llm_error_rate_limit_text_false_positive(self):
+        """测试说明性 rate limit/429 文本不会误判"""
+        event = {
+            "event": "on_llm_error",
+            "run_id": "run_llm",
+            "data": {
+                "error": RuntimeError(
+                    "ticket 429 mentions rate limit dashboard, auth failed"
+                ),
+            },
+        }
+
+        results = list(AgentRunConverter().to_agui_events(event))
+
+        assert len(results) == 1
+        assert results[0].event == EventType.ERROR
+        assert results[0].data["code"] == "LLM_ERROR"
+        assert "retryable" not in results[0].data
+        assert "retryAfterMs" not in results[0].data
 
     def test_on_chain_error(self):
         """测试 on_chain_error 事件

--- a/tests/unittests/server/test_agui_protocol.py
+++ b/tests/unittests/server/test_agui_protocol.py
@@ -102,6 +102,95 @@ class TestAGUIProtocolEndpoints:
         assert "RUN_ERROR" in types
 
     @pytest.mark.asyncio
+    async def test_error_event_addition_fields_preserved(self):
+        """测试 RUN_ERROR 编码保留扩展字段"""
+
+        def invoke_agent(request: AgentRequest):
+            yield AgentEvent(
+                event=EventType.ERROR,
+                data={
+                    "message": "模型当前请求过多，请稍后再试",
+                    "code": "RATE_LIMITED",
+                    "retryable": True,
+                    "type": "BROKEN",
+                },
+                addition={
+                    "retryAfterMs": 2000,
+                    "traceId": "trace-xyz",
+                    "type": "BROKEN",
+                },
+            )
+
+        client = self.get_client(invoke_agent)
+        response = client.post(
+            "/ag-ui/agent",
+            json={"messages": [{"role": "user", "content": "Hello"}]},
+        )
+
+        assert response.status_code == 200
+        assert "event: RUN_ERROR" in response.text
+        events = _agui_sse_events(response)
+        run_error = next(
+            event for event in events if event.get("type") == "RUN_ERROR"
+        )
+        assert run_error["type"] == "RUN_ERROR"
+        assert run_error["code"] == "RATE_LIMITED"
+        assert run_error["retryable"] is True
+        assert run_error["retryAfterMs"] == 2000
+        assert run_error["traceId"] == "trace-xyz"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_stream_payload(self):
+        """测试 429 错误输出结构化 RUN_ERROR 且无 RUN_FINISHED"""
+
+        class RateLimitError(RuntimeError):
+            status_code = 429
+
+        def invoke_agent(request: AgentRequest):
+            raise RateLimitError("model overloaded")
+
+        client = self.get_client(invoke_agent)
+        response = client.post(
+            "/ag-ui/agent",
+            json={"messages": [{"role": "user", "content": "Hello"}]},
+        )
+
+        assert response.status_code == 200
+        assert "event: RUN_ERROR" in response.text
+        events = _agui_sse_events(response)
+        types = [event.get("type") for event in events]
+        run_error = next(
+            event for event in events if event.get("type") == "RUN_ERROR"
+        )
+        assert "RUN_FINISHED" not in types
+        assert run_error["message"] == "模型当前请求过多，请稍后再试"
+        assert run_error["code"] == "RATE_LIMITED"
+        assert run_error["retryable"] is True
+        assert run_error["retryAfterMs"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_non_rate_limit_error_stream_payload(self):
+        """测试普通错误不会被误标为限流"""
+
+        def invoke_agent(request: AgentRequest):
+            raise RuntimeError("boom")
+
+        client = self.get_client(invoke_agent)
+        response = client.post(
+            "/ag-ui/agent",
+            json={"messages": [{"role": "user", "content": "Hello"}]},
+        )
+
+        assert response.status_code == 200
+        events = _agui_sse_events(response)
+        run_error = next(
+            event for event in events if event.get("type") == "RUN_ERROR"
+        )
+        assert run_error["code"] == "RuntimeError"
+        assert "retryable" not in run_error
+        assert "retryAfterMs" not in run_error
+
+    @pytest.mark.asyncio
     async def test_exception_in_parse_request(self):
         """测试 parse_request 中的异常处理（覆盖 155-156 行）
 

--- a/tests/unittests/server/test_agui_protocol.py
+++ b/tests/unittests/server/test_agui_protocol.py
@@ -125,6 +125,34 @@ class TestAGUIProtocolEndpoints:
         assert run_error["code"] == "RATE_LIMITED"
         assert run_error["retryable"] is True
         assert run_error["retryAfterMs"] == 2000
+        assert run_error["statusCode"] == 429
+
+    @pytest.mark.asyncio
+    async def test_text_model_error_stream_payload(self):
+        """测试模型侧错误文本输出 RUN_ERROR 且透出分类字段"""
+
+        def invoke_agent(request: AgentRequest):
+            return "Error code: 400 - data_inspection_failed: unsafe content"
+
+        client = self.get_client(invoke_agent)
+        response = client.post(
+            "/ag-ui/agent",
+            json={"messages": [{"role": "user", "content": "Hello"}]},
+        )
+
+        assert response.status_code == 200
+        events = _agui_sse_events(response)
+        types = [event.get("type") for event in events]
+        run_error = next(
+            event for event in events if event.get("type") == "RUN_ERROR"
+        )
+        assert "RUN_FINISHED" not in types
+        assert run_error["message"] == (
+            "Error code: 400 - data_inspection_failed: unsafe content"
+        )
+        assert run_error["code"] == "MODEL_DATA_INSPECTION_FAILED"
+        assert run_error["statusCode"] == 400
+        assert run_error["providerCode"] == "DataInspectionFailed"
 
     @pytest.mark.asyncio
     async def test_exception_in_parse_request(self):

--- a/tests/unittests/server/test_agui_protocol.py
+++ b/tests/unittests/server/test_agui_protocol.py
@@ -128,7 +128,7 @@ class TestAGUIProtocolEndpoints:
         )
 
         assert response.status_code == 200
-        assert "event: RUN_ERROR" in response.text
+        assert "event: RUN_ERROR" not in response.text
         events = _agui_sse_events(response)
         run_error = next(
             event for event in events if event.get("type") == "RUN_ERROR"
@@ -156,7 +156,7 @@ class TestAGUIProtocolEndpoints:
         )
 
         assert response.status_code == 200
-        assert "event: RUN_ERROR" in response.text
+        assert "event: RUN_ERROR" not in response.text
         events = _agui_sse_events(response)
         types = [event.get("type") for event in events]
         run_error = next(

--- a/tests/unittests/server/test_agui_protocol.py
+++ b/tests/unittests/server/test_agui_protocol.py
@@ -102,24 +102,11 @@ class TestAGUIProtocolEndpoints:
         assert "RUN_ERROR" in types
 
     @pytest.mark.asyncio
-    async def test_error_event_addition_fields_preserved(self):
-        """测试 RUN_ERROR 编码保留扩展字段"""
+    async def test_text_rate_limit_error_stream_payload(self):
+        """测试文本形式的 429 错误输出 RUN_ERROR 且无 RUN_FINISHED"""
 
         def invoke_agent(request: AgentRequest):
-            yield AgentEvent(
-                event=EventType.ERROR,
-                data={
-                    "message": "模型当前请求过多，请稍后再试",
-                    "code": "RATE_LIMITED",
-                    "retryable": True,
-                    "type": "BROKEN",
-                },
-                addition={
-                    "retryAfterMs": 2000,
-                    "traceId": "trace-xyz",
-                    "type": "BROKEN",
-                },
-            )
+            return "Error code: 429 - rate limit exceeded"
 
         client = self.get_client(invoke_agent)
         response = client.post(
@@ -128,67 +115,16 @@ class TestAGUIProtocolEndpoints:
         )
 
         assert response.status_code == 200
-        assert "event: RUN_ERROR" not in response.text
-        events = _agui_sse_events(response)
-        run_error = next(
-            event for event in events if event.get("type") == "RUN_ERROR"
-        )
-        assert run_error["type"] == "RUN_ERROR"
-        assert run_error["code"] == "RATE_LIMITED"
-        assert run_error["retryable"] is True
-        assert run_error["retryAfterMs"] == 2000
-        assert run_error["traceId"] == "trace-xyz"
-
-    @pytest.mark.asyncio
-    async def test_rate_limit_error_stream_payload(self):
-        """测试 429 错误输出结构化 RUN_ERROR 且无 RUN_FINISHED"""
-
-        class RateLimitError(RuntimeError):
-            status_code = 429
-
-        def invoke_agent(request: AgentRequest):
-            raise RateLimitError("model overloaded")
-
-        client = self.get_client(invoke_agent)
-        response = client.post(
-            "/ag-ui/agent",
-            json={"messages": [{"role": "user", "content": "Hello"}]},
-        )
-
-        assert response.status_code == 200
-        assert "event: RUN_ERROR" not in response.text
         events = _agui_sse_events(response)
         types = [event.get("type") for event in events]
         run_error = next(
             event for event in events if event.get("type") == "RUN_ERROR"
         )
         assert "RUN_FINISHED" not in types
-        assert run_error["message"] == "model overloaded"
+        assert run_error["message"] == "Error code: 429 - rate limit exceeded"
         assert run_error["code"] == "RATE_LIMITED"
         assert run_error["retryable"] is True
         assert run_error["retryAfterMs"] == 2000
-
-    @pytest.mark.asyncio
-    async def test_non_rate_limit_error_stream_payload(self):
-        """测试普通错误不会被误标为限流"""
-
-        def invoke_agent(request: AgentRequest):
-            raise RuntimeError("boom")
-
-        client = self.get_client(invoke_agent)
-        response = client.post(
-            "/ag-ui/agent",
-            json={"messages": [{"role": "user", "content": "Hello"}]},
-        )
-
-        assert response.status_code == 200
-        events = _agui_sse_events(response)
-        run_error = next(
-            event for event in events if event.get("type") == "RUN_ERROR"
-        )
-        assert run_error["code"] == "RuntimeError"
-        assert "retryable" not in run_error
-        assert "retryAfterMs" not in run_error
 
     @pytest.mark.asyncio
     async def test_exception_in_parse_request(self):

--- a/tests/unittests/server/test_agui_protocol.py
+++ b/tests/unittests/server/test_agui_protocol.py
@@ -163,7 +163,7 @@ class TestAGUIProtocolEndpoints:
             event for event in events if event.get("type") == "RUN_ERROR"
         )
         assert "RUN_FINISHED" not in types
-        assert run_error["message"] == "模型当前请求过多，请稍后再试"
+        assert run_error["message"] == "model overloaded"
         assert run_error["code"] == "RATE_LIMITED"
         assert run_error["retryable"] is True
         assert run_error["retryAfterMs"] == 2000

--- a/tests/unittests/server/test_error_utils.py
+++ b/tests/unittests/server/test_error_utils.py
@@ -1,0 +1,9 @@
+"""Tests for server error helpers."""
+
+from agentrun.server.error_utils import _get_header
+
+
+def test_get_header_matches_name_case_insensitively():
+    headers = {"x-trace-id": "trace-123"}
+
+    assert _get_header(headers, "X-Trace-ID") == "trace-123"

--- a/tests/unittests/server/test_error_utils.py
+++ b/tests/unittests/server/test_error_utils.py
@@ -1,9 +1,38 @@
 """Tests for server error helpers."""
 
-from agentrun.server.error_utils import _get_header
+from agentrun.utils.error_utils import _get_header, is_rate_limited_error
 
 
 def test_get_header_matches_name_case_insensitively():
     headers = {"x-trace-id": "trace-123"}
 
     assert _get_header(headers, "X-Trace-ID") == "trace-123"
+
+
+def test_explanatory_code_429_text_is_not_rate_limited():
+    error = RuntimeError("validation failed for field code 429")
+
+    assert not is_rate_limited_error(error)
+
+
+def test_explanatory_http_429_text_is_not_rate_limited():
+    error = RuntimeError(
+        "docs mention HTTP 429 means rate limit; actual error is 401"
+    )
+
+    assert not is_rate_limited_error(error)
+
+
+def test_explicit_throttling_text_is_rate_limited():
+    assert is_rate_limited_error(RuntimeError("Throttling: model overloaded"))
+
+
+def test_explicit_throttled_text_is_rate_limited():
+    assert is_rate_limited_error(RuntimeError("request throttled by provider"))
+
+
+def test_structured_status_429_is_rate_limited():
+    class RateLimitError(RuntimeError):
+        status_code = 429
+
+    assert is_rate_limited_error(RateLimitError("model overloaded"))

--- a/tests/unittests/server/test_error_utils.py
+++ b/tests/unittests/server/test_error_utils.py
@@ -1,13 +1,80 @@
-"""Tests for model rate-limit helpers."""
+"""Tests for model-side error helpers."""
+
+from types import SimpleNamespace
+
+import pytest
 
 from agentrun.utils.error_utils import (
     build_error_event_data,
+    classify_model_error,
+    is_model_error,
     is_rate_limited_error,
 )
 
 
 def test_text_429_rate_limit_is_rate_limited():
     assert is_rate_limited_error("Error code: 429 - rate limit exceeded")
+
+
+@pytest.mark.parametrize(
+    ("text", "code", "status_code", "retryable"),
+    [
+        (
+            "Error code: 400 - Arrearage: account is not in good standing",
+            "MODEL_ARREARAGE",
+            400,
+            False,
+        ),
+        (
+            "Error code: 400 - data_inspection_failed: unsafe content",
+            "MODEL_DATA_INSPECTION_FAILED",
+            400,
+            False,
+        ),
+        (
+            "Error code: 401 - InvalidApiKey: invalid api key",
+            "MODEL_AUTHENTICATION_ERROR",
+            401,
+            False,
+        ),
+        (
+            "Error code: 403 - AccessDenied.Unpurchased: model disabled",
+            "MODEL_ACCESS_DENIED",
+            403,
+            False,
+        ),
+        (
+            "Error code: 429 - Throttling.RateQuota: too many requests",
+            "RATE_LIMITED",
+            429,
+            True,
+        ),
+        (
+            "Error code: 500 - InternalError.Algo: backend failed",
+            "MODEL_INTERNAL_ERROR",
+            500,
+            True,
+        ),
+        (
+            "Error code: 503 - ModelServingError: model overloaded",
+            "MODEL_SERVICE_UNAVAILABLE",
+            503,
+            True,
+        ),
+    ],
+)
+def test_common_bailian_text_errors_are_model_errors(
+    text,
+    code,
+    status_code,
+    retryable,
+):
+    model_error = classify_model_error(text)
+
+    assert model_error is not None
+    assert model_error.code == code
+    assert model_error.status_code == status_code
+    assert model_error.retryable is retryable
 
 
 def test_structured_status_429_is_rate_limited():
@@ -17,8 +84,76 @@ def test_structured_status_429_is_rate_limited():
     assert is_rate_limited_error(RateLimitError("provider overloaded"))
 
 
+def test_structured_response_body_code_is_model_error():
+    error = SimpleNamespace(
+        response=SimpleNamespace(
+            status_code=403,
+            json=lambda: {
+                "code": "WorkspaceAccessDenied",
+                "requestId": "req-123",
+            },
+        )
+    )
+
+    data = build_error_event_data(
+        error,
+        fallback_code="RuntimeError",
+        fallback_message="workspace denied",
+    )
+
+    assert data == {
+        "message": "workspace denied",
+        "code": "MODEL_ACCESS_DENIED",
+        "statusCode": 403,
+        "providerCode": "WorkspaceAccessDenied",
+        "requestId": "req-123",
+    }
+
+
+@pytest.mark.parametrize(
+    ("text", "provider_code"),
+    [
+        (
+            "Error code: 403 - AccessDenied.Unpurchased: model disabled",
+            "AccessDenied.Unpurchased",
+        ),
+        (
+            "Error code: 429 - Throttling.RateQuota: too many requests",
+            "Throttling.RateQuota",
+        ),
+        (
+            "Error code: 500 - InternalError.Algo: backend failed",
+            "InternalError.Algo",
+        ),
+    ],
+)
+def test_text_provider_code_preserves_dotted_suffix(text, provider_code):
+    data = build_error_event_data(
+        text,
+        fallback_code="str",
+        fallback_message=text,
+    )
+
+    assert data["providerCode"] == provider_code
+
+
 def test_non_rate_limit_text_is_not_rate_limited():
     assert not is_rate_limited_error("normal response")
+
+
+def test_plain_internal_error_is_not_model_error():
+    assert not is_model_error("Internal error")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Error code: 400 - validation failed",
+        "HTTP 500 - Internal Server Error means the service failed",
+    ],
+)
+def test_status_code_only_text_is_not_model_error(text):
+    assert not is_model_error(text)
 
 
 def test_rate_limit_event_uses_original_message():
@@ -33,4 +168,5 @@ def test_rate_limit_event_uses_original_message():
         "code": "RATE_LIMITED",
         "retryable": True,
         "retryAfterMs": 2000,
+        "statusCode": 429,
     }

--- a/tests/unittests/server/test_error_utils.py
+++ b/tests/unittests/server/test_error_utils.py
@@ -1,38 +1,36 @@
-"""Tests for server error helpers."""
+"""Tests for model rate-limit helpers."""
 
-from agentrun.utils.error_utils import _get_header, is_rate_limited_error
-
-
-def test_get_header_matches_name_case_insensitively():
-    headers = {"x-trace-id": "trace-123"}
-
-    assert _get_header(headers, "X-Trace-ID") == "trace-123"
+from agentrun.utils.error_utils import (
+    build_error_event_data,
+    is_rate_limited_error,
+)
 
 
-def test_explanatory_code_429_text_is_not_rate_limited():
-    error = RuntimeError("validation failed for field code 429")
-
-    assert not is_rate_limited_error(error)
-
-
-def test_explanatory_http_429_text_is_not_rate_limited():
-    error = RuntimeError(
-        "docs mention HTTP 429 means rate limit; actual error is 401"
-    )
-
-    assert not is_rate_limited_error(error)
-
-
-def test_explicit_throttling_text_is_rate_limited():
-    assert is_rate_limited_error(RuntimeError("Throttling: model overloaded"))
-
-
-def test_explicit_throttled_text_is_rate_limited():
-    assert is_rate_limited_error(RuntimeError("request throttled by provider"))
+def test_text_429_rate_limit_is_rate_limited():
+    assert is_rate_limited_error("Error code: 429 - rate limit exceeded")
 
 
 def test_structured_status_429_is_rate_limited():
     class RateLimitError(RuntimeError):
         status_code = 429
 
-    assert is_rate_limited_error(RateLimitError("model overloaded"))
+    assert is_rate_limited_error(RateLimitError("provider overloaded"))
+
+
+def test_non_rate_limit_text_is_not_rate_limited():
+    assert not is_rate_limited_error("normal response")
+
+
+def test_rate_limit_event_uses_original_message():
+    data = build_error_event_data(
+        "Error code: 429 - rate limit exceeded",
+        fallback_code="str",
+        fallback_message="Error code: 429 - rate limit exceeded",
+    )
+
+    assert data == {
+        "message": "Error code: 429 - rate limit exceeded",
+        "code": "RATE_LIMITED",
+        "retryable": True,
+        "retryAfterMs": 2000,
+    }

--- a/tests/unittests/server/test_invoker.py
+++ b/tests/unittests/server/test_invoker.py
@@ -188,6 +188,142 @@ class TestInvokerStream:
         assert "Test error" in error_event.data["message"]
         assert error_event.data["code"] == "ValueError"
 
+    @pytest.mark.asyncio
+    async def test_invoke_stream_rate_limit_error(self, req):
+        """测试模型限流错误被归一化"""
+
+        class RateLimitError(RuntimeError):
+            status_code = 429
+            trace_id = "trace-123"
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            raise RateLimitError("model overloaded")
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        error_event = next(
+            item for item in items if item.event == EventType.ERROR
+        )
+        assert error_event.data["message"] == "模型当前请求过多，请稍后再试"
+        assert error_event.data["code"] == "RATE_LIMITED"
+        assert error_event.data["retryable"] is True
+        assert error_event.data["retryAfterMs"] == 2000
+        assert error_event.data["traceId"] == "trace-123"
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_response_rate_limit_error(self, req):
+        """测试 response.status_code=429 不被顶层非 429 状态掩盖"""
+
+        class RateLimitError(RuntimeError):
+            status_code = 0
+            code = "Other"
+            response = {"status_code": 429}
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            raise RateLimitError("model overloaded")
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        error_event = next(
+            item for item in items if item.event == EventType.ERROR
+        )
+        assert error_event.data["code"] == "RATE_LIMITED"
+        assert error_event.data["retryable"] is True
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_rate_limit_code_exception(self, req):
+        """测试带 Exception 后缀的限流错误码被识别"""
+
+        class RateLimitError(RuntimeError):
+            code = "TooManyRequestsException"
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            raise RateLimitError("model overloaded")
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        error_event = next(
+            item for item in items if item.event == EventType.ERROR
+        )
+        assert error_event.data["code"] == "RATE_LIMITED"
+        assert error_event.data["retryAfterMs"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_response_rate_limit_code(self, req):
+        """测试 response.code 不被顶层非限流 code 掩盖"""
+
+        class RateLimitError(RuntimeError):
+            code = "Other"
+            response = {"code": "TooManyRequests"}
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            raise RateLimitError("model overloaded")
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        error_event = next(
+            item for item in items if item.event == EventType.ERROR
+        )
+        assert error_event.data["code"] == "RATE_LIMITED"
+        assert error_event.data["retryAfterMs"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_rate_limit_snake_case_text(self, req):
+        """测试明确 snake_case 限流文本被识别"""
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            raise RuntimeError("rate_limit_exceeded: retry later")
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        error_event = next(
+            item for item in items if item.event == EventType.ERROR
+        )
+        assert error_event.data["code"] == "RATE_LIMITED"
+        assert error_event.data["retryAfterMs"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_rate_limit_text_false_positive(self, req):
+        """测试说明性 rate limit/429 文本不会被误判为限流"""
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            raise RuntimeError(
+                "ticket 429 mentions rate limit dashboard, auth failed"
+            )
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        error_event = next(
+            item for item in items if item.event == EventType.ERROR
+        )
+        assert error_event.data["code"] == "RuntimeError"
+        assert "retryable" not in error_event.data
+        assert "retryAfterMs" not in error_event.data
+
 
 class TestInvokerSync:
     """同步调用测试"""

--- a/tests/unittests/server/test_invoker.py
+++ b/tests/unittests/server/test_invoker.py
@@ -189,15 +189,11 @@ class TestInvokerStream:
         assert error_event.data["code"] == "ValueError"
 
     @pytest.mark.asyncio
-    async def test_invoke_stream_rate_limit_error(self, req):
-        """测试模型限流错误被归一化"""
-
-        class RateLimitError(RuntimeError):
-            status_code = 429
-            trace_id = "trace-123"
+    async def test_invoke_stream_text_rate_limit_error(self, req):
+        """测试字符串形式的模型限流错误被转成 ERROR"""
 
         async def invoke_agent(req: AgentRequest) -> str:
-            raise RateLimitError("model overloaded")
+            return "Error code: 429 - rate limit exceeded"
 
         invoker = AgentInvoker(invoke_agent)
 
@@ -205,124 +201,12 @@ class TestInvokerStream:
         async for item in invoker.invoke_stream(req):
             items.append(item)
 
-        error_event = next(
-            item for item in items if item.event == EventType.ERROR
-        )
-        assert error_event.data["message"] == "model overloaded"
-        assert error_event.data["code"] == "RATE_LIMITED"
-        assert error_event.data["retryable"] is True
-        assert error_event.data["retryAfterMs"] == 2000
-        assert error_event.data["traceId"] == "trace-123"
-
-    @pytest.mark.asyncio
-    async def test_invoke_stream_response_rate_limit_error(self, req):
-        """测试 response.status_code=429 不被顶层非 429 状态掩盖"""
-
-        class RateLimitError(RuntimeError):
-            status_code = 0
-            code = "Other"
-            response = {"status_code": 429}
-
-        async def invoke_agent(req: AgentRequest) -> str:
-            raise RateLimitError("model overloaded")
-
-        invoker = AgentInvoker(invoke_agent)
-
-        items: List[AgentEvent] = []
-        async for item in invoker.invoke_stream(req):
-            items.append(item)
-
-        error_event = next(
-            item for item in items if item.event == EventType.ERROR
-        )
-        assert error_event.data["code"] == "RATE_LIMITED"
-        assert error_event.data["retryable"] is True
-
-    @pytest.mark.asyncio
-    async def test_invoke_stream_rate_limit_code_exception(self, req):
-        """测试带 Exception 后缀的限流错误码被识别"""
-
-        class RateLimitError(RuntimeError):
-            code = "TooManyRequestsException"
-
-        async def invoke_agent(req: AgentRequest) -> str:
-            raise RateLimitError("model overloaded")
-
-        invoker = AgentInvoker(invoke_agent)
-
-        items: List[AgentEvent] = []
-        async for item in invoker.invoke_stream(req):
-            items.append(item)
-
-        error_event = next(
-            item for item in items if item.event == EventType.ERROR
-        )
-        assert error_event.data["code"] == "RATE_LIMITED"
-        assert error_event.data["retryAfterMs"] == 2000
-
-    @pytest.mark.asyncio
-    async def test_invoke_stream_response_rate_limit_code(self, req):
-        """测试 response.code 不被顶层非限流 code 掩盖"""
-
-        class RateLimitError(RuntimeError):
-            code = "Other"
-            response = {"code": "TooManyRequests"}
-
-        async def invoke_agent(req: AgentRequest) -> str:
-            raise RateLimitError("model overloaded")
-
-        invoker = AgentInvoker(invoke_agent)
-
-        items: List[AgentEvent] = []
-        async for item in invoker.invoke_stream(req):
-            items.append(item)
-
-        error_event = next(
-            item for item in items if item.event == EventType.ERROR
-        )
-        assert error_event.data["code"] == "RATE_LIMITED"
-        assert error_event.data["retryAfterMs"] == 2000
-
-    @pytest.mark.asyncio
-    async def test_invoke_stream_rate_limit_snake_case_text(self, req):
-        """测试明确 snake_case 限流文本被识别"""
-
-        async def invoke_agent(req: AgentRequest) -> str:
-            raise RuntimeError("rate_limit_exceeded: retry later")
-
-        invoker = AgentInvoker(invoke_agent)
-
-        items: List[AgentEvent] = []
-        async for item in invoker.invoke_stream(req):
-            items.append(item)
-
-        error_event = next(
-            item for item in items if item.event == EventType.ERROR
-        )
-        assert error_event.data["code"] == "RATE_LIMITED"
-        assert error_event.data["retryAfterMs"] == 2000
-
-    @pytest.mark.asyncio
-    async def test_invoke_stream_rate_limit_text_false_positive(self, req):
-        """测试说明性 rate limit/429 文本不会被误判为限流"""
-
-        async def invoke_agent(req: AgentRequest) -> str:
-            raise RuntimeError(
-                "ticket 429 mentions rate limit dashboard, auth failed"
-            )
-
-        invoker = AgentInvoker(invoke_agent)
-
-        items: List[AgentEvent] = []
-        async for item in invoker.invoke_stream(req):
-            items.append(item)
-
-        error_event = next(
-            item for item in items if item.event == EventType.ERROR
-        )
-        assert error_event.data["code"] == "RuntimeError"
-        assert "retryable" not in error_event.data
-        assert "retryAfterMs" not in error_event.data
+        assert len(items) == 1
+        assert items[0].event == EventType.ERROR
+        assert items[0].data["message"] == "Error code: 429 - rate limit exceeded"
+        assert items[0].data["code"] == "RATE_LIMITED"
+        assert items[0].data["retryable"] is True
+        assert items[0].data["retryAfterMs"] == 2000
 
 
 class TestInvokerSync:

--- a/tests/unittests/server/test_invoker.py
+++ b/tests/unittests/server/test_invoker.py
@@ -203,10 +203,54 @@ class TestInvokerStream:
 
         assert len(items) == 1
         assert items[0].event == EventType.ERROR
-        assert items[0].data["message"] == "Error code: 429 - rate limit exceeded"
+        assert (
+            items[0].data["message"] == "Error code: 429 - rate limit exceeded"
+        )
         assert items[0].data["code"] == "RATE_LIMITED"
         assert items[0].data["retryable"] is True
         assert items[0].data["retryAfterMs"] == 2000
+        assert items[0].data["statusCode"] == 429
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_text_model_error(self, req):
+        """测试字符串形式的模型权限错误被转成 ERROR"""
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            return "Error code: 403 - AccessDenied: model is not authorized"
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        assert len(items) == 1
+        assert items[0].event == EventType.ERROR
+        assert items[0].data["message"] == (
+            "Error code: 403 - AccessDenied: model is not authorized"
+        )
+        assert items[0].data["code"] == "MODEL_ACCESS_DENIED"
+        assert items[0].data["statusCode"] == 403
+        assert items[0].data["providerCode"] == "AccessDenied"
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_status_code_text_stays_text(self, req):
+        """测试普通状态码说明文本不会被误转成 ERROR"""
+
+        async def invoke_agent(req: AgentRequest) -> str:
+            return "HTTP 500 - Internal Server Error means the service failed"
+
+        invoker = AgentInvoker(invoke_agent)
+
+        items: List[AgentEvent] = []
+        async for item in invoker.invoke_stream(req):
+            items.append(item)
+
+        assert len(items) == 1
+        assert items[0].event == EventType.TEXT
+        assert items[0].data["delta"] == (
+            "HTTP 500 - Internal Server Error means the service failed"
+        )
 
 
 class TestInvokerSync:

--- a/tests/unittests/server/test_invoker.py
+++ b/tests/unittests/server/test_invoker.py
@@ -208,7 +208,7 @@ class TestInvokerStream:
         error_event = next(
             item for item in items if item.event == EventType.ERROR
         )
-        assert error_event.data["message"] == "模型当前请求过多，请稍后再试"
+        assert error_event.data["message"] == "model overloaded"
         assert error_event.data["code"] == "RATE_LIMITED"
         assert error_event.data["retryable"] is True
         assert error_event.data["retryAfterMs"] == 2000


### PR DESCRIPTION
Keep the change inside the SDK error-to-AG-UI boundary: detect structured 429/rate-limit signals, preserve RATE_LIMITED retry metadata on RUN_ERROR, and keep non-rate errors on their existing codes.

Constraint: Aone 83566999 requires model limit errors to end the AG-UI stream with RUN_ERROR rather than client-delivered text.

Rejected: funagent-core/front-end rewrite | downstream AG-UI frames are already pass-through and the SDK owns event semantics.

Rejected: broad generic error framework | current need is a small rate-limit normalizer.

Confidence: high

Scope-risk: narrow

Directive: Keep RUN_ERROR payload extensions whitelisted and preserve SSE event framing when adding fields.

Tested: uv run --extra server pytest tests/unittests/server/test_invoker.py tests/unittests/server/test_agui_protocol.py tests/unittests/integration/test_langgraph_events.py -q => 101 passed, 1 warning

Tested: uv run --extra server pytest tests/unittests/integration/test_langgraph_to_agent_event.py -q => 32 passed

Tested: git diff --check && uv run ruff check agentrun/server/error_utils.py agentrun/server/invoker.py agentrun/server/agui_protocol.py agentrun/integration/langgraph/agent_converter.py => passed

Tested: UltraQA dynamic AG-UI harness UQA-1..UQA-4 => passed

Change-Id: Ice926e2c21201071713ac39faeed736078fc5823
Co-developed-by: Codex <noreply@openai.com>
Not-tested: full repository test suite and remote CI pending

> Thank you for creating a pull request to contribute to Serverless Devs agentrun-sdk-python code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
> Please select one of the PR types below to complete 

---------------------

## Fix bugs

**Bug detail**
> The specific manifestation of the bug or the associated issue.

**Pull request tasks**
- [ ] Add test cases for the changes
- [ ] Passed the CI test

---------------------

## Update docs

**Reason for update**
> Why do you need to update your documentation?

**Pull request tasks**
- [ ] Update Chinese documentation
- [ ] Update English documentation

---------------------

## Add contributor

**Contributed content**
- [ ] Code
- [ ] Document

**Content detail**
```
if content_type == 'code' || content_type == 'document':
    please tell us `PR url`，like: https://github.com/Serverless-Devs/agentrun-sdk-python/pull/1
else:
    please describe your contribution in detail
```

---------------------

## Others

**Reason for update**
> Why do you need to update your documentation?
